### PR TITLE
Add -version argument to show version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@
 IMAGE_NAME=quay.io/k8scsi/csi-attacher
 IMAGE_VERSION=canary
 
+REV=$(shell git describe --long --match='v*' --dirty)
+
 ifdef V
 TESTARGS = -v -args -alsologtostderr -v 5
 else
@@ -28,7 +30,7 @@ all: csi-attacher
 
 csi-attacher:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ./bin/csi-attacher ./cmd/csi-attacher
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/csi-attacher ./cmd/csi-attacher
 
 clean:
 	-rm -rf bin

--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -52,11 +52,22 @@ var (
 	connectionTimeout = flag.Duration("connection-timeout", 1*time.Minute, "Timeout for waiting for CSI driver socket.")
 	csiAddress        = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
 	dummy             = flag.Bool("dummy", false, "Run in dummy mode, i.e. not connecting to CSI driver and marking everything as attached. Expected CSI driver name is \"csi/dummy\".")
+	showVersion       = flag.Bool("version", false, "Show version.")
+)
+
+var (
+	version = "unknown"
 )
 
 func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(os.Args[0], version)
+		return
+	}
+	glog.Infof("Version: %s", version)
 
 	// Create the client config. Use kubeconfig if given, otherwise assume in-cluster.
 	config, err := buildConfig(*kubeconfig)


### PR DESCRIPTION
Fixes: #43 

`make` does:
    ```
    go build -a -ldflags '-X main.version=v0.2.0-12-gc8c6307-dirty -extldflags "-static"' -o ./bin/csi-attacher ./cmd/csi-attacher
    ```

And then:

```sh
$ bin/csi-attacher -version
bin/csi-attacher v0.2.0-12-gc8c6307-dirty
```
It shows git commit even when current head == some tag. I left it there to be able distinguish different builds when we force-retag something.

@lpabon @sbezverk PTAL
This should go to every CSI binary eventually.