### PR TITLE
Set dependency based on a tag kubernetes-1.12.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -346,7 +346,6 @@
   version = "v2.1.1"
 
 [[projects]]
-  branch = "release-1.12"
   digest = "1:5f076f6f9c3ac4f2b99d79dc7974eabd3f51be35254aa0d8c4cf920fdb9c7ff8"
   name = "k8s.io/api"
   packages = [
@@ -383,10 +382,10 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "507f29373a170184d325ea007e032b686bb189ac"
+  revision = "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
+  version = "kubernetes-1.12.0"
 
 [[projects]]
-  branch = "release-1.12"
   digest = "1:7aa037a4df5432be2820d164f378d7c22335e5cbba124e90e42114757ebd11ac"
   name = "k8s.io/apimachinery"
   packages = [
@@ -435,9 +434,10 @@
   ]
   pruneopts = ""
   revision = "6dd46049f39503a1fc8d65de4bd566829e95faff"
+  version = "kubernetes-1.12.0"
 
 [[projects]]
-  digest = "1:f750eea76a41b0d4fcf8ba4a8df3bd3158b96c6179991408ae596433f772f297"
+  digest = "1:5d4153d12c3aed2c90a94262520d2498d5afa4d692554af55e65a7c5af0bc399"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -609,8 +609,8 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "f95740e171023a8be8649df0e40ece69cd095bd8"
-  version = "kubernetes-1.12.0-rc.2"
+  revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
+  version = "kubernetes-1.12.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,15 +26,15 @@
 
 [[constraint]]
   name = "k8s.io/api"
-  branch = "release-1.12"
+  version = "kubernetes-1.12.0"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  branch = "release-1.12"
+  version = "kubernetes-1.12.0"
 
 [[constraint]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.12.0-rc.2"
+  version = "kubernetes-1.12.0"
 
 [[override]]
   name = "github.com/json-iterator/go"

--- a/vendor/k8s.io/client-go/Godeps/Godeps.json
+++ b/vendor/k8s.io/client-go/Godeps/Godeps.json
@@ -272,131 +272,131 @@
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/admissionregistration/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/apps/v1beta2",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authentication/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/authorization/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/autoscaling/v2beta2",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/batch/v2alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/certificates/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/coordination/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/core/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/events/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/extensions/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/imagepolicy/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/networking/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/policy/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/rbac/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/scheduling/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/settings/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1alpha1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/api/storage/v1beta1",
-			"Rev": "21fd097ab3de3d49f55ffc09491bf5368856a15b"
+			"Rev": "fd83cbc87e7632ccd8bbab63d2b673d4e0c631cc"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/apitesting",


### PR DESCRIPTION
This PR updates the Gopkg.yaml file to point to the kubernetes-1.12.0
tag because content on the release-1.12 branch could be changing over time.