### PR TITLE
Store NodeID in annotation

### DIFF
--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -276,10 +276,11 @@ const (
 	testNodeID       = "nodeID1"
 )
 
-func createVolumeAttachment(attacher string, pvName string, nodeName string, attached bool, finalizers string) *storage.VolumeAttachment {
+func createVolumeAttachment(attacher string, pvName string, nodeName string, attached bool, finalizers string, annotations map[string]string) *storage.VolumeAttachment {
 	va := &storage.VolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: pvName + "-" + nodeName,
+			Name:        pvName + "-" + nodeName,
+			Annotations: annotations,
 		},
 		Spec: storage.VolumeAttachmentSpec{
 			Attacher: attacher,
@@ -298,8 +299,8 @@ func createVolumeAttachment(attacher string, pvName string, nodeName string, att
 	return va
 }
 
-func va(attached bool, finalizers string) *storage.VolumeAttachment {
-	return createVolumeAttachment(testAttacherName, testPVName, testNodeName, attached, finalizers)
+func va(attached bool, finalizers string, annotations map[string]string) *storage.VolumeAttachment {
+	return createVolumeAttachment(testAttacherName, testPVName, testNodeName, attached, finalizers, annotations)
 }
 
 func deleted(va *storage.VolumeAttachment) *storage.VolumeAttachment {
@@ -318,7 +319,7 @@ func vaWithNoPVReference(va *storage.VolumeAttachment) *storage.VolumeAttachment
 }
 
 func vaWithInvalidDriver(va *storage.VolumeAttachment) *storage.VolumeAttachment {
-	return createVolumeAttachment("unknownDriver", testPVName, testNodeName, false, "")
+	return createVolumeAttachment("unknownDriver", testPVName, testNodeName, false, "", nil)
 }
 
 func vaWithAttachError(va *storage.VolumeAttachment, message string) *storage.VolumeAttachment {

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -47,26 +47,26 @@ func TestTrivialHandler(t *testing.T) {
 	tests := []testCase{
 		{
 			name:    "add -> successful write",
-			addedVA: va(false, ""),
+			addedVA: va(false, "", nil),
 			expectedActions: []core.Action{
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "")),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
 			},
 		},
 		{
 			name:      "update -> successful write",
-			updatedVA: va(false, ""),
+			updatedVA: va(false, "", nil),
 			expectedActions: []core.Action{
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "")),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
 			},
 		},
 		{
 			name:            "unknown driver -> controller ignores",
-			addedVA:         vaWithInvalidDriver(va(false, "")),
+			addedVA:         vaWithInvalidDriver(va(false, "", nil)),
 			expectedActions: []core.Action{},
 		},
 		{
 			name:    "failed write -> controller retries",
-			addedVA: va(false, ""),
+			addedVA: va(false, "", nil),
 			reactors: []reaction{
 				{
 					verb:     "update",
@@ -86,9 +86,9 @@ func TestTrivialHandler(t *testing.T) {
 				},
 			},
 			expectedActions: []core.Action{
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "")),
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "")),
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "")),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
 			},
 		},
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -87,6 +87,7 @@ const (
 	defaultFSType              = "ext4"
 	nodeIDAnnotation           = "csi.volume.kubernetes.io/nodeid"
 	csiVolAttribsAnnotationKey = "csi.volume.kubernetes.io/volume-attributes"
+	vaNodeIDAnnotation         = "csi.alpha.kubernetes.io/node-id"
 )
 
 func SanitizeDriverName(driver string) string {


### PR DESCRIPTION
So the node / CSINodeInfo object can be deleted and detach continutes to work.

Fixes: #83
