### PR TITLE
rbac: fix kubectl validation error

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -79,3 +79,4 @@ subjects:
 roleRef:
   kind: Role
   name: external-attacher-cfg
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The files worked fine in automated testing, but kubectl complains
about the missing apiGroup.