### PR TITLE
Remove explicit `nil` error initialization.

### DIFF
--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -119,7 +119,7 @@ func TestGetPluginInfo(t *testing.T) {
 		in := &csi.GetPluginInfoRequest{}
 
 		out := test.output
-		var injectedErr error = nil
+		var injectedErr error
 		if test.injectError {
 			injectedErr = fmt.Errorf("mock error")
 		}
@@ -257,7 +257,7 @@ func TestSupportsControllerPublish(t *testing.T) {
 		in := &csi.ControllerGetCapabilitiesRequest{}
 
 		out := test.output
-		var injectedErr error = nil
+		var injectedErr error
 		if test.injectError {
 			injectedErr = fmt.Errorf("mock error")
 		}
@@ -364,7 +364,7 @@ func TestSupportsPluginControllerService(t *testing.T) {
 		in := &csi.GetPluginCapabilitiesRequest{}
 
 		out := test.output
-		var injectedErr error = nil
+		var injectedErr error
 		if test.injectError {
 			injectedErr = fmt.Errorf("mock error")
 		}
@@ -541,7 +541,7 @@ func TestAttach(t *testing.T) {
 	for _, test := range tests {
 		in := test.input
 		out := test.output
-		var injectedErr error = nil
+		var injectedErr error
 		if test.injectError != codes.OK {
 			injectedErr = status.Error(test.injectError, fmt.Sprintf("Injecting error %d", test.injectError))
 		}
@@ -646,7 +646,7 @@ func TestDetachAttach(t *testing.T) {
 	for _, test := range tests {
 		in := test.input
 		out := test.output
-		var injectedErr error = nil
+		var injectedErr error
 		if test.injectError != codes.OK {
 			injectedErr = status.Error(test.injectError, fmt.Sprintf("Injecting error %d", test.injectError))
 		}

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -245,12 +245,12 @@ func TestCSIHandler(t *testing.T) {
 		Resource: "secrets",
 	}
 
-	var noMetadata map[string]string = nil
-	var noAttrs map[string]string = nil
-	var noSecrets map[string]string = nil
+	var noMetadata map[string]string
+	var noAttrs map[string]string
+	var noSecrets map[string]string
 	var notDetached = false
 	var detached = true
-	var success error = nil
+	var success error
 	var readWrite = false
 	var readOnly = true
 
@@ -923,11 +923,11 @@ func TestCSIHandlerReadOnly(t *testing.T) {
 		Version:  "v1beta1",
 		Resource: "volumeattachments",
 	}
-	var noMetadata map[string]string = nil
-	var noAttrs map[string]string = nil
-	var noSecrets map[string]string = nil
+	var noMetadata map[string]string
+	var noAttrs map[string]string
+	var noSecrets map[string]string
 	var notDetached = false
-	var success error = nil
+	var success error
 	var readWrite = false
 
 	tests := []testCase{


### PR DESCRIPTION
initialization of nil make go-lint unhappy. Removing it via this PR.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>