### PR TITLE
release tools: fix canary push + enhance testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,1 @@
-language: go
-sudo: required
-services:
-  - docker
-matrix:
-  include:
-  - go: 1.10.3
-script:
-- go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
-- go vet $(go list ./... | grep -v vendor)
-- go test $(go list ./... | grep -v vendor)
-- make
-after_success:
-  - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-      docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" quay.io;
-      make push;
-    fi
+release-tools/travis.yml

--- a/Makefile
+++ b/Makefile
@@ -12,37 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all csi-attacher clean test
+CMDS=csi-attacher
+all: build
 
-REGISTRY_NAME=quay.io/k8scsi
-IMAGE_NAME=csi-attacher
-IMAGE_VERSION=canary
-IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
+include release-tools/build.make
 
-REV=$(shell git describe --long --tags --match='v*' --dirty)
-
-ifdef V
-TESTARGS = -v -args -alsologtostderr -v 5
-else
-TESTARGS =
-endif
-
-
-all: csi-attacher
-
-csi-attacher:
-	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/csi-attacher ./cmd/csi-attacher
-
-clean:
-	-rm -rf bin
-
-container: csi-attacher
-	docker build -t $(IMAGE_TAG) .
-
-push: container
-	docker push $(IMAGE_TAG)
-
-test:
-	go test `go list ./... | grep -v 'vendor'` $(TESTARGS)
-	go vet `go list ./... | grep -v vendor`


### PR DESCRIPTION
Updating "release-tools" fixes the pushing of the "canary" image from master and enhances the output of "make test".
