### PR TITLE
update owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,12 @@
 approvers:
-- saad-ali
 - jsafrane
 - lpabon
 - msau42
+- saad-ali
 reviewers:
-- sbezverk
 - davidz627
+- jsafrane
+- lpabon
+- msau42
+- saad-ali
+- sbezverk


### PR DESCRIPTION
* Add all the approvers to reviewers because the bot chooses 1 from approver and 1 from reviewer
* sort alphabetically to make it easier to read