### PR TITLE
Check if volumeHandler was set

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/api/core/v1"
@@ -189,6 +190,9 @@ func GetVolumeCapabilities(pv *v1.PersistentVolume, csiSource *v1.CSIPersistentV
 func GetVolumeHandle(csiSource *v1.CSIPersistentVolumeSource) (string, bool, error) {
 	if csiSource == nil {
 		return "", false, fmt.Errorf("csi source was nil")
+	}
+	if len(strings.TrimSpace(csiSource.VolumeHandle)) == 0 {
+		return "", false, fmt.Errorf("volume handle was not set")
 	}
 	return csiSource.VolumeHandle, csiSource.ReadOnly, nil
 }


### PR DESCRIPTION
Check if volumeHandler was set before call "Attach".  If a PV was created by storgeClasses, volumeHandler must not be empty. However, if it was created by a user, it is possible empty, e.g.

apiVersion: v1
kind: PersistentVolume
metadata:
  name: test
  namespace: "default"
spec:
  accessModes:
  - ReadWriteOnce
  capacity:
    storage: 5Gi
  csi:
    driver: "XXX"
    volumeHandle: " "

I think, attacher should not call "Attach" in this scenario.