### PR TITLE
Cherry pick #144 to release-1.1: fix default leader election type

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -49,6 +49,9 @@ const (
 
 	// Name of CSI plugin for dummy operation
 	dummyAttacherName = "csi/dummy"
+
+	leaderElectionTypeLeases     = "leases"
+	leaderElectionTypeConfigMaps = "configmaps"
 )
 
 // Command line flags
@@ -62,7 +65,7 @@ var (
 	timeout           = flag.Duration("timeout", 15*time.Second, "Timeout for waiting for attaching or detaching the volume.")
 
 	enableLeaderElection    = flag.Bool("leader-election", false, "Enable leader election.")
-	leaderElectionType      = flag.String("leader-election-type", "configmap", "the type of leader election, options are 'configmaps' (default) or 'leases' (recommended). The 'configmaps' option is deprecated in favor of 'leases'.")
+	leaderElectionType      = flag.String("leader-election-type", leaderElectionTypeConfigMaps, "the type of leader election, options are 'configmaps' (default) or 'leases' (recommended). The 'configmaps' option is deprecated in favor of 'leases'.")
 	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
 	_                       = deprecatedflags.Add("leader-election-identity")
 )
@@ -191,13 +194,13 @@ func main() {
 
 		// Name of config map with leader election lock
 		lockName := "external-attacher-leader-" + csiAttacher
-		if *leaderElectionType == "configmaps" {
-			klog.Warning("The 'configmaps' leader election type is deprecated and will be removed in a future release. Use '--leader-election-type=leases' instead.")
+		if *leaderElectionType == leaderElectionTypeConfigMaps {
+			klog.Warningf("The '%s' leader election type is deprecated and will be removed in a future release. Use '--leader-election-type=%s' instead.", leaderElectionTypeConfigMaps, leaderElectionTypeLeases)
 			le = leaderelection.NewLeaderElectionWithConfigMaps(clientset, lockName, run)
-		} else if *leaderElectionType == "leases" {
+		} else if *leaderElectionType == leaderElectionTypeLeases {
 			le = leaderelection.NewLeaderElection(clientset, lockName, run)
 		} else {
-			klog.Error("--leader-election-type must be either 'configmap' or 'lease'")
+			klog.Errorf("--leader-election-type must be either '%s' or '%s'", leaderElectionTypeConfigMaps, leaderElectionTypeLeases)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cherry pick #144 to release-1.1: fix default leader election type

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes default leader election type to be 'configmaps'
```
