### PR TITLE
Revert "Use patch to replace update"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -699,7 +699,6 @@
   input-imports = [
     "github.com/container-storage-interface/spec/lib/go/csi",
     "github.com/davecgh/go-spew/spew",
-    "github.com/evanphx/json-patch",
     "github.com/golang/mock/gomock",
     "github.com/golang/protobuf/proto",
     "github.com/kubernetes-csi/csi-lib-utils/connection",
@@ -720,7 +719,6 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/core/v1",

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -33,7 +33,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["get", "list", "watch", "update"]
 #Secret permission is optional.
 #Enable it if you need value from secret.
 #For example, you have key `csi.storage.k8s.io/controller-publish-secret-name` in StorageClass.parameters

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -192,7 +192,7 @@ func (h *csiHandler) prepareVANodeID(va *storage.VolumeAttachment, nodeID string
 }
 
 func (h *csiHandler) saveVA(va *storage.VolumeAttachment) (*storage.VolumeAttachment, error) {
-	// TODO: use patch to save us from VersionError
+	// TODO: #158 #157: use patch to save us from VersionError
 	newVA, err := h.client.StorageV1beta1().VolumeAttachments().Update(va)
 	if err != nil {
 		return va, err
@@ -215,7 +215,7 @@ func (h *csiHandler) addPVFinalizer(pv *v1.PersistentVolume) (*v1.PersistentVolu
 	klog.V(4).Infof("Adding finalizer to PV %q", pv.Name)
 	clone := pv.DeepCopy()
 	clone.Finalizers = append(clone.Finalizers, finalizerName)
-	// TODO: use patch to save us from VersionError
+	// TODO: #158 #157: use patch to save us from VersionError
 	newPV, err := h.client.CoreV1().PersistentVolumes().Update(clone)
 	if err != nil {
 		return pv, err

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -29,8 +29,7 @@ import (
 	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
 	"k8s.io/klog"
 
-	"encoding/json"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -243,30 +242,6 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 				if o.Status.DetachError != nil {
 					o.Status.DetachError.Time = metav1.Time{}
 				}
-			}
-
-			if action.GetVerb() == "patch" && action.GetResource().Resource == "volumeattachments" {
-				patchAction := action.(core.PatchActionImpl)
-				patch := patchAction.GetPatch()
-				var va storage.VolumeAttachment
-				err := json.Unmarshal(patch, &va)
-				if va.Status.AttachError != nil {
-					va.Status.AttachError.Time = metav1.Time{}
-				}
-				if va.Status.DetachError != nil {
-					va.Status.DetachError.Time = metav1.Time{}
-				}
-
-				if va.Status.AttachError != nil || va.Status.DetachError != nil {
-
-					patch, err = createMergePatch(storage.VolumeAttachment{}, va)
-					if err != nil {
-						t.Errorf("Test %q create patch failed", t.Name())
-					}
-					patchAction.Patch = patch
-					action = patchAction
-				}
-
 			}
 
 			expectedAction := test.expectedActions[i]

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	core "k8s.io/client-go/testing"
@@ -49,20 +48,14 @@ func TestTrivialHandler(t *testing.T) {
 			name:    "add -> successful write",
 			addedVA: va(false, "", nil),
 			expectedActions: []core.Action{
-				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
-					types.MergePatchType, patch(
-						va(false, "", nil),
-						va(true, "", nil))),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
 			},
 		},
 		{
 			name:      "update -> successful write",
 			updatedVA: va(false, "", nil),
 			expectedActions: []core.Action{
-				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
-					types.MergePatchType, patch(
-						va(false, "", nil),
-						va(true, "", nil))),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
 			},
 		},
 		{
@@ -75,7 +68,7 @@ func TestTrivialHandler(t *testing.T) {
 			addedVA: va(false, "", nil),
 			reactors: []reaction{
 				{
-					verb:     "patch",
+					verb:     "update",
 					resource: "volumeattachments",
 					reactor: func(t *testing.T) core.ReactionFunc {
 						i := 0
@@ -92,18 +85,9 @@ func TestTrivialHandler(t *testing.T) {
 				},
 			},
 			expectedActions: []core.Action{
-				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
-					types.MergePatchType, patch(
-						va(false, "", nil),
-						va(true, "", nil))),
-				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
-					types.MergePatchType, patch(
-						va(false, "", nil),
-						va(true, "", nil))),
-				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
-					types.MergePatchType, patch(
-						va(false, "", nil),
-						va(true, "", nil))),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
 			},
 		},
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -34,7 +34,7 @@ func markAsAttached(client kubernetes.Interface, va *storage.VolumeAttachment, m
 	clone.Status.Attached = true
 	clone.Status.AttachmentMetadata = metadata
 	clone.Status.AttachError = nil
-	// TODO: use patch to save us from VersionError
+	// TODO: #158 #157: use patch to save us from VersionError
 	newVA, err := client.StorageV1beta1().VolumeAttachments().Update(clone)
 	if err != nil {
 		return va, err
@@ -73,7 +73,7 @@ func markAsDetached(client kubernetes.Interface, va *storage.VolumeAttachment) (
 	clone.Status.Attached = false
 	clone.Status.DetachError = nil
 	clone.Status.AttachmentMetadata = nil
-	// TODO: use patch to save us from VersionError
+	// TODO: #158 #157: use patch to save us from VersionError
 	newVA, err := client.StorageV1beta1().VolumeAttachments().Update(clone)
 	if err != nil {
 		return va, err

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -22,10 +22,8 @@ import (
 	"regexp"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/evanphx/json-patch"
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
@@ -36,11 +34,8 @@ func markAsAttached(client kubernetes.Interface, va *storage.VolumeAttachment, m
 	clone.Status.Attached = true
 	clone.Status.AttachmentMetadata = metadata
 	clone.Status.AttachError = nil
-	patch, err := createMergePatch(va, clone)
-	if err != nil {
-		return va, err
-	}
-	newVA, err := client.StorageV1beta1().VolumeAttachments().Patch(va.Name, types.MergePatchType, patch)
+	// TODO: use patch to save us from VersionError
+	newVA, err := client.StorageV1beta1().VolumeAttachments().Update(clone)
 	if err != nil {
 		return va, err
 	}
@@ -78,11 +73,8 @@ func markAsDetached(client kubernetes.Interface, va *storage.VolumeAttachment) (
 	clone.Status.Attached = false
 	clone.Status.DetachError = nil
 	clone.Status.AttachmentMetadata = nil
-	patch, err := createMergePatch(va, clone)
-	if err != nil {
-		return va, err
-	}
-	newVA, err := client.StorageV1beta1().VolumeAttachments().Patch(va.Name, types.MergePatchType, patch)
+	// TODO: use patch to save us from VersionError
+	newVA, err := client.StorageV1beta1().VolumeAttachments().Update(clone)
 	if err != nil {
 		return va, err
 	}
@@ -219,21 +211,4 @@ func GetVolumeAttributes(csiSource *v1.CSIPersistentVolumeSource) (map[string]st
 		return nil, fmt.Errorf("csi source was nil")
 	}
 	return csiSource.VolumeAttributes, nil
-}
-
-// createMergePatch return patch generated from original and new interfaces
-func createMergePatch(original, new interface{}) ([]byte, error) {
-	pvByte, err := json.Marshal(original)
-	if err != nil {
-		return nil, err
-	}
-	cloneByte, err := json.Marshal(new)
-	if err != nil {
-		return nil, err
-	}
-	patch, err := jsonpatch.CreateMergePatch(pvByte, cloneByte)
-	if err != nil {
-		return nil, err
-	}
-	return patch, nil
 }


### PR DESCRIPTION
This reverts commit f95364717f0fb1028185e0276ba20536e941ddaa.

PATCH usage introduced in #149 needs new RBAC rules and that effectively breaks API. We don't want to bump the image to v2.0 (yet).

ddebroy @davidz627 PTAL, I think I fixed in-line attachment unit tests correctly.

@cwdsuzhou, sorry, your contribution is great, however we'd prefer to be on the safe side. We'll keep your patch around when v2.0 time comes.

/kind api-change
(?)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
