### PR TITLE
Translate PV so that the pvSpec is also translated for things like AccessModes etc

### DIFF
--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package controller
 
 import (
@@ -195,7 +210,7 @@ func TestGetVolumeCapabilities(t *testing.T) {
 				},
 			},
 		}
-		cap, err := GetVolumeCapabilities(&pv.Spec, pv.Spec.CSI)
+		cap, err := GetVolumeCapabilities(&pv.Spec)
 
 		if err == nil && test.expectError {
 			t.Errorf("test %s: expected error, got none", test.name)


### PR DESCRIPTION
/kind bug
/kind failing-test

Fixes a bug where the `pvSpec` was not translated and thus didn't pick up the backwards compatibility changes made in the `pvSpec` when getting `AccessModes` in particular

/assign @msau42 @ddebroy 
/cc @leakingtapan

```release-note
Fix issue to actually translate backwards compatible access modes for CSI Migration
```
