### PR TITLE
Fixed ControllerUnpublish error handling

### DIFF
--- a/pkg/attacher/attacher_test.go
+++ b/pkg/attacher/attacher_test.go
@@ -291,54 +291,60 @@ func TestDetachAttach(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		volumeID       string
-		nodeID         string
-		secrets        map[string]string
-		input          *csi.ControllerUnpublishVolumeRequest
-		output         *csi.ControllerUnpublishVolumeResponse
-		injectError    codes.Code
-		expectError    bool
-		expectDetached bool
+		name        string
+		volumeID    string
+		nodeID      string
+		secrets     map[string]string
+		input       *csi.ControllerUnpublishVolumeRequest
+		output      *csi.ControllerUnpublishVolumeResponse
+		injectError codes.Code
+		expectError bool
 	}{
 		{
-			name:           "success",
-			volumeID:       defaultVolumeID,
-			nodeID:         defaultNodeID,
-			input:          defaultRequest,
-			output:         &csi.ControllerUnpublishVolumeResponse{},
-			expectError:    false,
-			expectDetached: true,
+			name:        "success",
+			volumeID:    defaultVolumeID,
+			nodeID:      defaultNodeID,
+			input:       defaultRequest,
+			output:      &csi.ControllerUnpublishVolumeResponse{},
+			expectError: false,
 		},
 		{
-			name:           "secrets",
-			volumeID:       defaultVolumeID,
-			nodeID:         defaultNodeID,
-			secrets:        map[string]string{"foo": "bar"},
-			input:          secretsRequest,
-			output:         &csi.ControllerUnpublishVolumeResponse{},
-			expectError:    false,
-			expectDetached: true,
+			name:        "secrets",
+			volumeID:    defaultVolumeID,
+			nodeID:      defaultNodeID,
+			secrets:     map[string]string{"foo": "bar"},
+			input:       secretsRequest,
+			output:      &csi.ControllerUnpublishVolumeResponse{},
+			expectError: false,
 		},
 		{
-			name:           "gRPC final error",
-			volumeID:       defaultVolumeID,
-			nodeID:         defaultNodeID,
-			input:          defaultRequest,
-			output:         nil,
-			injectError:    codes.NotFound,
-			expectError:    true,
-			expectDetached: true,
+			name:        "gRPC final error",
+			volumeID:    defaultVolumeID,
+			nodeID:      defaultNodeID,
+			input:       defaultRequest,
+			output:      nil,
+			injectError: codes.PermissionDenied,
+			expectError: true,
 		},
 		{
-			name:           "gRPC transient error",
-			volumeID:       defaultVolumeID,
-			nodeID:         defaultNodeID,
-			input:          defaultRequest,
-			output:         nil,
-			injectError:    codes.DeadlineExceeded,
-			expectError:    true,
-			expectDetached: false,
+			name:        "gRPC transient error",
+			volumeID:    defaultVolumeID,
+			nodeID:      defaultNodeID,
+			input:       defaultRequest,
+			output:      nil,
+			injectError: codes.DeadlineExceeded,
+			expectError: true,
+		},
+		{
+			// Explicitly test NotFound, it's handled as any other error.
+			// https://github.com/kubernetes-csi/external-attacher/pull/165
+			name:        "gRPC NotFound error",
+			volumeID:    defaultVolumeID,
+			nodeID:      defaultNodeID,
+			input:       defaultRequest,
+			output:      nil,
+			injectError: codes.NotFound,
+			expectError: true,
 		},
 	}
 
@@ -365,15 +371,12 @@ func TestDetachAttach(t *testing.T) {
 		}
 
 		a := NewAttacher(csiConn)
-		detached, err := a.Detach(context.Background(), test.volumeID, test.nodeID, test.secrets)
+		err := a.Detach(context.Background(), test.volumeID, test.nodeID, test.secrets)
 		if test.expectError && err == nil {
 			t.Errorf("test %q: Expected error, got none", test.name)
 		}
 		if !test.expectError && err != nil {
 			t.Errorf("test %q: got error: %v", test.name, err)
-		}
-		if detached != test.expectDetached {
-			t.Errorf("test %q: expected detached=%v, got %v", test.name, test.expectDetached, detached)
 		}
 	}
 }

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -393,17 +393,13 @@ func (h *csiHandler) csiDetach(va *storage.VolumeAttachment) (*storage.VolumeAtt
 
 	ctx, cancel := context.WithTimeout(context.Background(), h.timeout)
 	defer cancel()
-	detached, err := h.attacher.Detach(ctx, volumeHandle, nodeID, secrets)
-	if err != nil && !detached {
+	err = h.attacher.Detach(ctx, volumeHandle, nodeID, secrets)
+	if err != nil {
 		// The volume may not be fully detached. Save the error and try again
 		// after backoff.
 		return va, err
 	}
-	if err != nil {
-		klog.V(2).Infof("Detached %q with error %s", va.Name, err.Error())
-	} else {
-		klog.V(2).Infof("Detached %q", va.Name)
-	}
+	klog.V(2).Infof("Detached %q", va.Name)
 
 	if va, err := markAsDetached(h.client, va); err != nil {
 		return va, fmt.Errorf("could not mark as detached: %s", err)

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -423,10 +423,10 @@ func (f *fakeCSIConnection) Attach(ctx context.Context, volumeID string, readOnl
 	return call.metadata, call.detached, call.err
 }
 
-func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID string, secrets map[string]string) (bool, error) {
+func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID string, secrets map[string]string) error {
 	if f.index >= len(f.calls) {
 		f.t.Errorf("Unexpected CSI Detach call: volume=%s, node=%s, index: %d, calls: %+v", volumeID, nodeID, f.index, f.calls)
-		return true, fmt.Errorf("unexpected call")
+		return fmt.Errorf("unexpected call")
 	}
 	call := f.calls[f.index]
 	f.index++
@@ -457,9 +457,9 @@ func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID 
 	}
 
 	if err != nil {
-		return true, err
+		return err
 	}
-	return call.detached, call.err
+	return call.err
 }
 
 func (f *fakeCSIConnection) Close() error {


### PR DESCRIPTION
Any error from ControllerUnpublish can mean that a volume could be still attached (or being detached).

**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #164

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Action required: processing of ControllerUnpublish errors has changed. CSI drivers SHOULD return success (0), when a deleted node or volume implies that the volume is detached from the node. The external attacher treats NotFound error as any other error and it assumes that the volume may still be attached to the node. Please check behavior of your CSI driver and fix it accordingly.
```

cc @kubernetes-csi/csi-misc 