### PR TITLE
1.0: Fixed ControllerUnpublish error handling

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -225,6 +225,12 @@ func (c *csiConnection) Detach(ctx context.Context, volumeID string, nodeID stri
 	}
 
 	_, err := client.ControllerUnpublishVolume(ctx, &req)
+	if err != nil && isNotFound(err) {
+		// Do not change behavior of NotFound in stable branches.
+		// See https://github.com/kubernetes-csi/external-attacher/pull/165 and
+		// https://github.com/container-storage-interface/spec/pull/375
+		return nil
+	}
 	return err
 }
 
@@ -267,4 +273,13 @@ func isFinalError(err error) bool {
 	// All other errors mean that the operation (attach/detach) either did not
 	// even start or failed. It is for sure not in progress.
 	return true
+}
+
+func isNotFound(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		// This is not gRPC error.
+		return false
+	}
+	return st.Code() == codes.NotFound
 }

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -629,15 +629,14 @@ func TestDetachAttach(t *testing.T) {
 			expectError: true,
 		},
 		{
-			// Explicitly test NotFound, it's handled as any other error.
-			// https://github.com/kubernetes-csi/external-attacher/pull/165
+			// Explicitly test NotFound, it should be ignored.
 			name:        "gRPC NotFound error",
 			volumeID:    defaultVolumeID,
 			nodeID:      defaultNodeID,
 			input:       defaultRequest,
 			output:      nil,
 			injectError: codes.NotFound,
-			expectError: true,
+			expectError: false,
 		},
 	}
 

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -26,7 +26,7 @@ import (
 	"github.com/kubernetes-csi/external-attacher/pkg/connection"
 
 	csiMigration "github.com/kubernetes-csi/kubernetes-csi-migration-library"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -365,17 +365,13 @@ func (h *csiHandler) csiDetach(va *storage.VolumeAttachment) (*storage.VolumeAtt
 
 	ctx, cancel := context.WithTimeout(context.Background(), h.timeout)
 	defer cancel()
-	detached, err := h.csiConnection.Detach(ctx, volumeHandle, nodeID, secrets)
-	if err != nil && !detached {
+	err = h.csiConnection.Detach(ctx, volumeHandle, nodeID, secrets)
+	if err != nil {
 		// The volume may not be fully detached. Save the error and try again
 		// after backoff.
 		return va, err
 	}
-	if err != nil {
-		glog.V(2).Infof("Detached %q with error %s", va.Name, err.Error())
-	} else {
-		glog.V(2).Infof("Detached %q", va.Name)
-	}
+	glog.V(2).Infof("Detached %q", va.Name)
 
 	if va, err := markAsDetached(h.client, va); err != nil {
 		return va, fmt.Errorf("could not mark as detached: %s", err)

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -409,10 +409,10 @@ func (f *fakeCSIConnection) Attach(ctx context.Context, volumeID string, readOnl
 	return call.metadata, call.detached, call.err
 }
 
-func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID string, secrets map[string]string) (bool, error) {
+func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID string, secrets map[string]string) error {
 	if f.index >= len(f.calls) {
 		f.t.Errorf("Unexpected CSI Detach call: volume=%s, node=%s, index: %d, calls: %+v", volumeID, nodeID, f.index, f.calls)
-		return true, fmt.Errorf("unexpected call")
+		return fmt.Errorf("unexpected call")
 	}
 	call := f.calls[f.index]
 	f.index++
@@ -443,9 +443,9 @@ func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID 
 	}
 
 	if err != nil {
-		return true, err
+		return err
 	}
-	return call.detached, call.err
+	return call.err
 }
 
 func (f *fakeCSIConnection) Close() error {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This is backport of https://github.com/kubernetes-csi/external-attacher/pull/165 into 1.0 branch.

I added extra code to interpret `NotFound` as success (i.e. a volume is considered as detached), so behavior of `NotFound` error handling is not changed in a stable branch.

```release-note
Fixed handling of ControllerUnpublish errors. The attacher will retry to ControllerUnpublish a volume after any error except for NotFound.
```

/assign @msau42 