### PR TITLE
Fix name of retry-interval-end parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note that the external-attacher does not scale with more replicas. Only one exte
 
 * `--retry-interval-start`: The exponential backoff for failures. See [CSI error and timeout handling](#csi-error-and-timeout-handling) for details. 1 second is used by default.
 
-* `--retry-interval-end`: The exponential backoff maximum value. See [CSI error and timeout handling](#csi-error-and-timeout-handling) for details. 5 minutes is used by default.
+* `--retry-interval-max`: The exponential backoff maximum value. See [CSI error and timeout handling](#csi-error-and-timeout-handling) for details. 5 minutes is used by default.
 
 #### Other recognized arguments
 


### PR DESCRIPTION
/kind cleanup
Fixes: #171

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
