### PR TITLE
2.0 prep: Revert "Revert "Use patch to replace update""

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -699,6 +699,7 @@
   input-imports = [
     "github.com/container-storage-interface/spec/lib/go/csi",
     "github.com/davecgh/go-spew/spew",
+    "github.com/evanphx/json-patch",
     "github.com/golang/mock/gomock",
     "github.com/golang/protobuf/proto",
     "github.com/kubernetes-csi/csi-lib-utils/connection",
@@ -719,6 +720,7 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/informers",
     "k8s.io/client-go/informers/core/v1",

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -33,7 +33,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
 #Secret permission is optional.
 #Enable it if you need value from secret.
 #For example, you have key `csi.storage.k8s.io/controller-publish-secret-name` in StorageClass.parameters

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -29,6 +29,7 @@ import (
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1beta1"
@@ -191,9 +192,8 @@ func (h *csiHandler) prepareVANodeID(va *storage.VolumeAttachment, nodeID string
 	return clone, true
 }
 
-func (h *csiHandler) saveVA(va *storage.VolumeAttachment) (*storage.VolumeAttachment, error) {
-	// TODO: #158 #157: use patch to save us from VersionError
-	newVA, err := h.client.StorageV1beta1().VolumeAttachments().Update(va)
+func (h *csiHandler) saveVA(va *storage.VolumeAttachment, patch []byte) (*storage.VolumeAttachment, error) {
+	newVA, err := h.client.StorageV1beta1().VolumeAttachments().Patch(va.Name, types.MergePatchType, patch)
 	if err != nil {
 		return va, err
 	}
@@ -215,11 +215,12 @@ func (h *csiHandler) addPVFinalizer(pv *v1.PersistentVolume) (*v1.PersistentVolu
 	klog.V(4).Infof("Adding finalizer to PV %q", pv.Name)
 	clone := pv.DeepCopy()
 	clone.Finalizers = append(clone.Finalizers, finalizerName)
-	// TODO: #158 #157: use patch to save us from VersionError
-	newPV, err := h.client.CoreV1().PersistentVolumes().Update(clone)
+
+	newPV, err := h.patchPV(pv, clone)
 	if err != nil {
 		return pv, err
 	}
+
 	klog.V(4).Infof("PV finalizer added to %q", pv.Name)
 	return newPV, nil
 }
@@ -327,10 +328,9 @@ func (h *csiHandler) csiAttach(va *storage.VolumeAttachment) (*storage.VolumeAtt
 	originalVA := va
 	va, finalizerAdded := h.prepareVAFinalizer(va)
 	va, nodeIDAdded := h.prepareVANodeID(va, nodeID)
+
 	if finalizerAdded || nodeIDAdded {
-		va, err = h.saveVA(va)
-		if err != nil {
-			// va modification failed, return the original va that's still on API server
+		if va, err = h.patchVA(originalVA, va); err != nil {
 			return originalVA, nil, fmt.Errorf("could not save VolumeAttachment: %s", err)
 		}
 	}
@@ -415,8 +415,9 @@ func (h *csiHandler) saveAttachError(va *storage.VolumeAttachment, err error) (*
 		Message: err.Error(),
 		Time:    metav1.Now(),
 	}
-	newVa, err := h.client.StorageV1beta1().VolumeAttachments().Update(clone)
-	if err != nil {
+
+	var newVa *storage.VolumeAttachment
+	if newVa, err = h.patchVA(va, clone); err != nil {
 		return va, err
 	}
 	klog.V(4).Infof("Saved attach error to %q", va.Name)
@@ -430,8 +431,9 @@ func (h *csiHandler) saveDetachError(va *storage.VolumeAttachment, err error) (*
 		Message: err.Error(),
 		Time:    metav1.Now(),
 	}
-	newVa, err := h.client.StorageV1beta1().VolumeAttachments().Update(clone)
-	if err != nil {
+
+	var newVa *storage.VolumeAttachment
+	if newVa, err = h.patchVA(va, clone); err != nil {
 		return va, err
 	}
 	klog.V(4).Infof("Saved detach error to %q", va.Name)
@@ -496,12 +498,13 @@ func (h *csiHandler) SyncNewOrUpdatedPersistentVolume(pv *v1.PersistentVolume) {
 		newFinalizers = nil
 	}
 	clone.Finalizers = newFinalizers
-	_, err = h.client.CoreV1().PersistentVolumes().Update(clone)
-	if err != nil {
+
+	if _, err = h.patchPV(pv, clone); err != nil {
 		klog.Errorf("Failed to remove finalizer from PV %q: %s", pv.Name, err.Error())
 		h.pvQueue.AddRateLimited(pv.Name)
 		return
 	}
+
 	klog.V(2).Infof("Removed finalizer from PV %q", pv.Name)
 	h.pvQueue.Forget(pv.Name)
 
@@ -563,4 +566,30 @@ func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.Volum
 
 	// return nodeLister.Get error
 	return "", err
+}
+
+func (h *csiHandler) patchVA(va, clone *storage.VolumeAttachment) (*storage.VolumeAttachment, error) {
+	patch, err := createMergePatch(va, clone)
+	if err != nil {
+		return va, err
+	}
+
+	newVa, err := h.client.StorageV1beta1().VolumeAttachments().Patch(va.Name, types.MergePatchType, patch)
+	if err != nil {
+		return va, err
+	}
+	return newVa, nil
+}
+
+func (h *csiHandler) patchPV(pv, clone *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	patch, err := createMergePatch(pv, clone)
+	if err != nil {
+		return pv, err
+	}
+
+	newPV, err := h.client.CoreV1().PersistentVolumes().Patch(pv.Name, types.MergePatchType, patch)
+	if err != nil {
+		return pv, err
+	}
+	return newPV, nil
 }

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -29,7 +29,8 @@ import (
 	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
 	"k8s.io/klog"
 
-	v1 "k8s.io/api/core/v1"
+	"encoding/json"
+	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -242,6 +243,30 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 				if o.Status.DetachError != nil {
 					o.Status.DetachError.Time = metav1.Time{}
 				}
+			}
+
+			if action.GetVerb() == "patch" && action.GetResource().Resource == "volumeattachments" {
+				patchAction := action.(core.PatchActionImpl)
+				patch := patchAction.GetPatch()
+				var va storage.VolumeAttachment
+				err := json.Unmarshal(patch, &va)
+				if va.Status.AttachError != nil {
+					va.Status.AttachError.Time = metav1.Time{}
+				}
+				if va.Status.DetachError != nil {
+					va.Status.DetachError.Time = metav1.Time{}
+				}
+
+				if va.Status.AttachError != nil || va.Status.DetachError != nil {
+
+					patch, err = createMergePatch(storage.VolumeAttachment{}, va)
+					if err != nil {
+						t.Errorf("Test %q create patch failed", t.Name())
+					}
+					patchAction.Patch = patch
+					action = patchAction
+				}
+
 			}
 
 			expectedAction := test.expectedActions[i]

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	core "k8s.io/client-go/testing"
@@ -48,14 +49,20 @@ func TestTrivialHandler(t *testing.T) {
 			name:    "add -> successful write",
 			addedVA: va(false, "", nil),
 			expectedActions: []core.Action{
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
+					types.MergePatchType, patch(
+						va(false, "", nil),
+						va(true, "", nil))),
 			},
 		},
 		{
 			name:      "update -> successful write",
 			updatedVA: va(false, "", nil),
 			expectedActions: []core.Action{
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
+					types.MergePatchType, patch(
+						va(false, "", nil),
+						va(true, "", nil))),
 			},
 		},
 		{
@@ -68,7 +75,7 @@ func TestTrivialHandler(t *testing.T) {
 			addedVA: va(false, "", nil),
 			reactors: []reaction{
 				{
-					verb:     "update",
+					verb:     "patch",
 					resource: "volumeattachments",
 					reactor: func(t *testing.T) core.ReactionFunc {
 						i := 0
@@ -85,9 +92,18 @@ func TestTrivialHandler(t *testing.T) {
 				},
 			},
 			expectedActions: []core.Action{
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
-				core.NewUpdateAction(vaGroupResourceVersion, metav1.NamespaceNone, va(true, "", nil)),
+				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
+					types.MergePatchType, patch(
+						va(false, "", nil),
+						va(true, "", nil))),
+				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
+					types.MergePatchType, patch(
+						va(false, "", nil),
+						va(true, "", nil))),
+				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
+					types.MergePatchType, patch(
+						va(false, "", nil),
+						va(true, "", nil))),
 			},
 		},
 	}


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This PR restores PATCH support in the external attacher. In v2.0 we can change the behavior and also the default RBAC rules that the attacher needs.

**Special notes for your reviewer**:
The first commit is the same as originally applied by @cwdsuzhou in #149. The second commit openly admits that the fake client / informer is imperfect and enables tests commented out by #149.

I tried to implement the fake PATCH correctly, however, applying `[]byte` patch to existing API object looks impossible.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Action required: The external-attacher now uses PATCH HTTP method to update API objects. Please update the attacher RBAC policy to allow the attacher to `patch`  VolumeAttachments and PersistentVolumes. See `deploy/kubernetes/rbac.yaml` for an example.
```
