### PR TITLE
Exit on connection loss

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -105,7 +105,7 @@ func main() {
 	factory := informers.NewSharedInformerFactory(clientset, *resync)
 	var handler controller.Handler
 	// Connect to CSI.
-	csiConn, err := connection.Connect(*csiAddress)
+	csiConn, err := connection.Connect(*csiAddress, connection.OnConnectionLoss(connection.ExitOnConnectionLoss()))
 	if err != nil {
 		klog.Error(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
Exist when a driver closes its socket.

1. The attacher caches driver capabilities, which could (in theory) change
after driver restart.

2. New driver may not come up for a while and the attacher should not act
as leader during this time.

/kind cleanup

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The external attacher now exits when it looses connection to a CSI driver. This speeds up re-election of a new attacher leader that has connection to the driver.
```
