### PR TITLE
Reconcile VolumeAttachment with ListVolumes Published Nodes

### DIFF
--- a/pkg/attacher/lister.go
+++ b/pkg/attacher/lister.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package attacher
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	"google.golang.org/grpc"
+)
+
+type CSIVolumeLister struct {
+	conn *grpc.ClientConn
+}
+
+// NewVolumeLister provides a new VolumeLister object.
+func NewVolumeLister(conn *grpc.ClientConn) *CSIVolumeLister {
+	return &CSIVolumeLister{
+		conn: conn,
+	}
+}
+
+func (a *CSIVolumeLister) ListVolumes(ctx context.Context) (map[string]([]string), error) {
+	client := csi.NewControllerClient(a.conn)
+
+	p := map[string][]string{}
+
+	tok := ""
+	for {
+		rsp, err := client.ListVolumes(ctx, &csi.ListVolumesRequest{
+			StartingToken: tok,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list volumes: %v", err)
+		}
+
+		for _, e := range rsp.Entries {
+			p[e.GetVolume().VolumeId] = e.Status.PublishedNodeIds
+		}
+		tok = rsp.NextToken
+
+		if len(tok) == 0 {
+			break
+		}
+	}
+
+	return p, nil
+}

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	core "k8s.io/client-go/testing"
-	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog"
 )
 
@@ -51,33 +50,35 @@ var (
 
 var timeout = 10 * time.Millisecond
 
-func csiHandlerFactory(client kubernetes.Interface, informerFactory informers.SharedInformerFactory, csi attacher.Attacher) Handler {
+func csiHandlerFactory(client kubernetes.Interface, informerFactory informers.SharedInformerFactory, csi attacher.Attacher, lister VolumeLister) Handler {
 	return NewCSIHandler(
 		client,
 		testAttacherName,
 		csi,
+		lister,
 		informerFactory.Core().V1().PersistentVolumes().Lister(),
 		informerFactory.Core().V1().Nodes().Lister(),
 		informerFactory.Storage().V1beta1().CSINodes().Lister(),
 		informerFactory.Storage().V1beta1().VolumeAttachments().Lister(),
 		&timeout,
 		true, /* supports PUBLISH_READONLY */
-		csitrans.New(),
+		fakeInTreeToCSITranslator{},
 	)
 }
 
-func csiHandlerFactoryNoReadOnly(client kubernetes.Interface, informerFactory informers.SharedInformerFactory, csi attacher.Attacher) Handler {
+func csiHandlerFactoryNoReadOnly(client kubernetes.Interface, informerFactory informers.SharedInformerFactory, csi attacher.Attacher, lister VolumeLister) Handler {
 	return NewCSIHandler(
 		client,
 		testAttacherName,
 		csi,
+		lister,
 		informerFactory.Core().V1().PersistentVolumes().Lister(),
 		informerFactory.Core().V1().Nodes().Lister(),
 		informerFactory.Storage().V1beta1().CSINodes().Lister(),
 		informerFactory.Storage().V1beta1().VolumeAttachments().Lister(),
 		&timeout,
 		false, /* does not support PUBLISH_READONLY */
-		csitrans.New(),
+		fakeInTreeToCSITranslator{},
 	)
 }
 
@@ -1273,6 +1274,64 @@ func TestCSIHandler(t *testing.T) {
 		},
 	}
 
+	runTests(t, csiHandlerFactory, tests)
+}
+
+func TestCSIHandlerReconcileVA(t *testing.T) {
+	nID := map[string]string{
+		vaNodeIDAnnotation: testNodeName,
+	}
+
+	tests := []testCase{
+		{
+			name: "va attached actual state not attached",
+			initialObjects: []runtime.Object{
+				va(true /*attached*/, "" /*finalizer*/, nID /*annotations*/),
+				pvWithFinalizer(),
+			},
+			listerResponse: map[string][]string{
+				// Intentionally empty
+			},
+			expectedCSICalls: []csiCall{
+				{"attach", testVolumeHandle, testNodeID, nil, nil, false, nil, false, nil, 0},
+			},
+		},
+		{
+			name: "va attached actual state attached",
+			initialObjects: []runtime.Object{
+				va(true /*attached*/, "" /*finalizer*/, nID /*annotations*/),
+				pvWithFinalizer(),
+			},
+			listerResponse: map[string][]string{
+				testVolumeHandle: []string{testNodeName},
+			},
+			expectedActions: []core.Action{
+				// Intentionally empty
+			},
+		},
+		{
+			name: "va not attached actual state attached",
+			initialObjects: []runtime.Object{
+				va(false /*attached*/, "" /*finalizer*/, nID /*annotations*/),
+				pvWithFinalizer(),
+			},
+			listerResponse: map[string][]string{
+				testVolumeHandle: []string{testNodeName},
+			},
+			expectedActions: []core.Action{},
+			expectedCSICalls: []csiCall{
+				{"detach", testVolumeHandle, testNodeID, nil, nil, false, nil, true, nil, 0},
+			},
+		},
+		{
+			name:           "no volume attachments but existing lister response results in no action",
+			initialObjects: []runtime.Object{},
+			listerResponse: map[string][]string{
+				testVolumeHandle: []string{testNodeName},
+			},
+			expectedActions: []core.Action{},
+		},
+	}
 	runTests(t, csiHandlerFactory, tests)
 }
 

--- a/pkg/controller/trivial_handler.go
+++ b/pkg/controller/trivial_handler.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
@@ -43,6 +43,10 @@ func NewTrivialHandler(client kubernetes.Interface) Handler {
 func (h *trivialHandler) Init(vaQueue workqueue.RateLimitingInterface, pvQueue workqueue.RateLimitingInterface) {
 	h.vaQueue = vaQueue
 	h.pvQueue = pvQueue
+}
+
+func (h *trivialHandler) ReconcileVA() error {
+	return nil
 }
 
 func (h *trivialHandler) SyncNewOrUpdatedVolumeAttachment(va *storage.VolumeAttachment) {

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -33,7 +33,7 @@ import (
 	core "k8s.io/client-go/testing"
 )
 
-func trivialHandlerFactory(client kubernetes.Interface, informerFactory informers.SharedInformerFactory, csi attacher.Attacher) Handler {
+func trivialHandlerFactory(client kubernetes.Interface, informerFactory informers.SharedInformerFactory, csi attacher.Attacher, lister VolumeLister) Handler {
 	return NewTrivialHandler(client)
 }
 


### PR DESCRIPTION
Main code-paths ready for review.

Tested with one dynamically provisioned volume with the native PD CSI Driver. After detaching the volume on the cloud provider -> external-attacher logs show correct identification of state change and update of VolumeAttachment object -> external-attacher succeeds with immediate reattachment of volume.

WIP:
- [x] Depends on CSI Spec `1.2`.
- [x] Depends on https://github.com/kubernetes/kubernetes/pull/83593
- [x] Only reconcile volumes if plugin supports `ListVolumePublishedNodes` capability
- [x] Handle migration cases for volume ID
- [x] Update logging to include verbosity
- [x] Write some unit tests

/kind feature
/assign @jsafrane @msau42 

```release-note
Reconciles VolumeAttachment attachment status with actual back-end volume attachment state if plugin supports LIST_VOLUMES_PUBLISHED_NODES capability.
```
