### PR TITLE
Use v1.CSINode in the external-attacher

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -155,7 +155,7 @@ func main() {
 		if supportsAttach {
 			pvLister := factory.Core().V1().PersistentVolumes().Lister()
 			vaLister := factory.Storage().V1().VolumeAttachments().Lister()
-			csiNodeLister := factory.Storage().V1beta1().CSINodes().Lister()
+			csiNodeLister := factory.Storage().V1().CSINodes().Lister()
 			volAttacher := attacher.NewAttacher(csiConn)
 			CSIVolumeLister := attacher.NewVolumeLister(csiConn)
 			handler = controller.NewCSIHandler(clientset, csiAttacher, volAttacher, CSIVolumeLister, pvLister, csiNodeLister, vaLister, timeout, supportsReadOnly, csitrans.New())

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
-	storagelistersv1beta1 "k8s.io/client-go/listers/storage/v1beta1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 )
@@ -62,7 +61,7 @@ type csiHandler struct {
 	attacher                attacher.Attacher
 	CSIVolumeLister         VolumeLister
 	pvLister                corelisters.PersistentVolumeLister
-	csiNodeLister           storagelistersv1beta1.CSINodeLister
+	csiNodeLister           storagelisters.CSINodeLister
 	vaLister                storagelisters.VolumeAttachmentLister
 	vaQueue, pvQueue        workqueue.RateLimitingInterface
 	forceSync               map[string]bool
@@ -81,7 +80,7 @@ func NewCSIHandler(
 	attacher attacher.Attacher,
 	CSIVolumeLister VolumeLister,
 	pvLister corelisters.PersistentVolumeLister,
-	csiNodeLister storagelistersv1beta1.CSINodeLister,
+	csiNodeLister storagelisters.CSINodeLister,
 	vaLister storagelisters.VolumeAttachmentLister,
 	timeout *time.Duration,
 	supportsPublishReadOnly bool,

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -26,7 +26,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,7 +57,7 @@ func csiHandlerFactory(client kubernetes.Interface, informerFactory informers.Sh
 		csi,
 		lister,
 		informerFactory.Core().V1().PersistentVolumes().Lister(),
-		informerFactory.Storage().V1beta1().CSINodes().Lister(),
+		informerFactory.Storage().V1().CSINodes().Lister(),
 		informerFactory.Storage().V1().VolumeAttachments().Lister(),
 		&timeout,
 		true, /* supports PUBLISH_READONLY */
@@ -73,7 +72,7 @@ func csiHandlerFactoryNoReadOnly(client kubernetes.Interface, informerFactory in
 		csi,
 		lister,
 		informerFactory.Core().V1().PersistentVolumes().Lister(),
-		informerFactory.Storage().V1beta1().CSINodes().Lister(),
+		informerFactory.Storage().V1().CSINodes().Lister(),
 		informerFactory.Storage().V1().VolumeAttachments().Lister(),
 		&timeout,
 		false, /* does not support PUBLISH_READONLY */
@@ -205,13 +204,13 @@ func nodeWithAnnotations() *v1.Node {
 	return node
 }
 
-func csiNode() *storagev1beta1.CSINode {
-	return &storagev1beta1.CSINode{
+func csiNode() *storage.CSINode {
+	return &storage.CSINode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNodeName,
 		},
-		Spec: storagev1beta1.CSINodeSpec{
-			Drivers: []storagev1beta1.CSINodeDriver{
+		Spec: storage.CSINodeSpec{
+			Drivers: []storage.CSINodeDriver{
 				{
 					Name:   testAttacherName,
 					NodeID: testNodeID,
@@ -221,12 +220,12 @@ func csiNode() *storagev1beta1.CSINode {
 	}
 }
 
-func csiNodeEmpty() *storagev1beta1.CSINode {
-	return &storagev1beta1.CSINode{
+func csiNodeEmpty() *storage.CSINode {
+	return &storage.CSINode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNodeName,
 		},
-		Spec: storagev1beta1.CSINodeSpec{Drivers: []storagev1beta1.CSINodeDriver{}},
+		Spec: storage.CSINodeSpec{Drivers: []storage.CSINodeDriver{}},
 	}
 }
 

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -31,7 +31,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -124,7 +123,7 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 		csiObjs := []runtime.Object{}
 		for _, obj := range objs {
 			switch obj.(type) {
-			case *storagev1beta1.CSINode:
+			case *storage.CSINode:
 				csiObjs = append(csiObjs, obj)
 			default:
 				coreObjs = append(coreObjs, obj)
@@ -137,7 +136,7 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 		vaInformer := informers.Storage().V1().VolumeAttachments()
 		pvInformer := informers.Core().V1().PersistentVolumes()
 		nodeInformer := informers.Core().V1().Nodes()
-		csiNodeInformer := informers.Storage().V1beta1().CSINodes()
+		csiNodeInformer := informers.Storage().V1().CSINodes()
 		// Fill the informers with initial objects so controller can Get() them
 		for _, obj := range objs {
 			switch obj.(type) {
@@ -149,7 +148,7 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 				vaInformer.Informer().GetStore().Add(obj)
 			case *v1.Secret:
 				// Secrets are not cached in any informer
-			case *storagev1beta1.CSINode:
+			case *storage.CSINode:
 				csiNodeInformer.Informer().GetStore().Add(obj)
 			default:
 				t.Fatalf("Unknown initalObject type: %+v", obj)

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -24,10 +24,9 @@ import (
 	"regexp"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/evanphx/json-patch"
-	"k8s.io/api/core/v1"
+	jsonpatch "github.com/evanphx/json-patch"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -119,7 +118,7 @@ func GetFinalizerName(driver string) string {
 }
 
 // GetNodeIDFromCSINode returns nodeID from CSIDriverInfoSpec
-func GetNodeIDFromCSINode(driver string, csiNode *storagev1beta1.CSINode) (string, bool) {
+func GetNodeIDFromCSINode(driver string, csiNode *storage.CSINode) (string, bool) {
 	for _, d := range csiNode.Spec.Drivers {
 		if d.Name == driver {
 			return d.NodeID, true


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR changes to attacher to use the GA version of the CSINode object.

**Which issue(s) this PR fixes**:

Fixes #197

**Does this PR introduce a user-facing change?**:

```release-note
Use GA version of CSINode object.
```
