### PR TITLE
Cherry-pick to 2.1: go module requirements for semantic versioning

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -36,8 +36,8 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
-	"github.com/kubernetes-csi/external-attacher/pkg/controller"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/controller"
 	"google.golang.org/grpc"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/external-attacher
 
-go 1.12
+go 1.13
 
 require (
 	github.com/container-storage-interface/spec v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/external-attacher
+module github.com/kubernetes-csi/external-attacher/v2
 
 go 1.13
 

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v2/pkg/attacher"
 
 	storage "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,18 @@
+This directory mirrors the source code via symlinks.
+This makes it possible to vendor v2.x releases of
+external-attacher with `dep` versions that do not
+support semantic imports. Support for that is currently
+[pending in dep](https://github.com/golang/dep/pull/1963).
+
+If users of dep have enabled pruning, they must disable if
+for external-attacher in their Gopk.toml, like this:
+
+```toml
+[prune]
+  go-tests = true
+  unused-packages = true
+
+  [[prune.project]]
+    name = "github.com/kubernetes-csi/external-attacher"
+    unused-packages = false
+```

--- a/v2/cmd/csi-attacher/main.go
+++ b/v2/cmd/csi-attacher/main.go
@@ -1,0 +1,1 @@
+../../../cmd/csi-attacher/main.go

--- a/v2/pkg/attacher/attacher.go
+++ b/v2/pkg/attacher/attacher.go
@@ -1,0 +1,1 @@
+../../../pkg/attacher/attacher.go

--- a/v2/pkg/attacher/attacher_test.go
+++ b/v2/pkg/attacher/attacher_test.go
@@ -1,0 +1,1 @@
+../../../pkg/attacher/attacher_test.go

--- a/v2/pkg/attacher/lister.go
+++ b/v2/pkg/attacher/lister.go
@@ -1,0 +1,1 @@
+../../../pkg/attacher/lister.go

--- a/v2/pkg/controller/controller.go
+++ b/v2/pkg/controller/controller.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/controller.go

--- a/v2/pkg/controller/controller_test.go
+++ b/v2/pkg/controller/controller_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/controller_test.go

--- a/v2/pkg/controller/csi_handler.go
+++ b/v2/pkg/controller/csi_handler.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/csi_handler.go

--- a/v2/pkg/controller/csi_handler_test.go
+++ b/v2/pkg/controller/csi_handler_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/csi_handler_test.go

--- a/v2/pkg/controller/framework_test.go
+++ b/v2/pkg/controller/framework_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/framework_test.go

--- a/v2/pkg/controller/trivial_handler.go
+++ b/v2/pkg/controller/trivial_handler.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/trivial_handler.go

--- a/v2/pkg/controller/trivial_handler_test.go
+++ b/v2/pkg/controller/trivial_handler_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/trivial_handler_test.go

--- a/v2/pkg/controller/util.go
+++ b/v2/pkg/controller/util.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/util.go

--- a/v2/pkg/controller/util_test.go
+++ b/v2/pkg/controller/util_test.go
@@ -1,0 +1,1 @@
+../../../pkg/controller/util_test.go


### PR DESCRIPTION
Backport go module requirements for semantic versioning (#209) to release-2.1 branch.


**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Fix go module requirements for semantic versioning

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Cherry pick PR #209: fix: go module requirements for semantic versioning
```
