### PR TITLE
Removed dependency on node annotation in favor of CSINode resource

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -154,12 +154,11 @@ func main() {
 		}
 		if supportsAttach {
 			pvLister := factory.Core().V1().PersistentVolumes().Lister()
-			nodeLister := factory.Core().V1().Nodes().Lister()
 			vaLister := factory.Storage().V1beta1().VolumeAttachments().Lister()
 			csiNodeLister := factory.Storage().V1beta1().CSINodes().Lister()
 			volAttacher := attacher.NewAttacher(csiConn)
 			CSIVolumeLister := attacher.NewVolumeLister(csiConn)
-			handler = controller.NewCSIHandler(clientset, csiAttacher, volAttacher, CSIVolumeLister, pvLister, nodeLister, csiNodeLister, vaLister, timeout, supportsReadOnly, csitrans.New())
+			handler = controller.NewCSIHandler(clientset, csiAttacher, volAttacher, CSIVolumeLister, pvLister, csiNodeLister, vaLister, timeout, supportsReadOnly, csitrans.New())
 			klog.V(2).Infof("CSI driver supports ControllerPublishUnpublish, using real CSI handler")
 		} else {
 			handler = controller.NewTrivialHandler(clientset)

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: default
 
 ---
-# Attacher must be able to work with PVs, nodes and VolumeAttachments
+# Attacher must be able to work with PVs, CSINodes and VolumeAttachments
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,9 +25,6 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -62,7 +62,6 @@ type csiHandler struct {
 	attacher                attacher.Attacher
 	CSIVolumeLister         VolumeLister
 	pvLister                corelisters.PersistentVolumeLister
-	nodeLister              corelisters.NodeLister
 	csiNodeLister           storagelisters.CSINodeLister
 	vaLister                storagelisters.VolumeAttachmentLister
 	vaQueue, pvQueue        workqueue.RateLimitingInterface
@@ -82,7 +81,6 @@ func NewCSIHandler(
 	attacher attacher.Attacher,
 	CSIVolumeLister VolumeLister,
 	pvLister corelisters.PersistentVolumeLister,
-	nodeLister corelisters.NodeLister,
 	csiNodeLister storagelisters.CSINodeLister,
 	vaLister storagelisters.VolumeAttachmentLister,
 	timeout *time.Duration,
@@ -95,7 +93,6 @@ func NewCSIHandler(
 		attacher:                attacher,
 		CSIVolumeLister:         CSIVolumeLister,
 		pvLister:                pvLister,
-		nodeLister:              nodeLister,
 		csiNodeLister:           csiNodeLister,
 		vaLister:                vaLister,
 		timeout:                 *timeout,
@@ -682,7 +679,7 @@ func (h *csiHandler) getCredentialsFromPV(csiSource *v1.CSIPersistentVolumeSourc
 	return credentials, nil
 }
 
-// getNodeID finds node ID from Node API object. If caller wants, it can find
+// getNodeID finds node ID from CSINode API object. If caller wants, it can find
 // node ID stored in VolumeAttachment annotation.
 func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.VolumeAttachment) (string, error) {
 	// Try to find CSINode first.
@@ -709,7 +706,7 @@ func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.Volum
 		return nodeID, nil
 	}
 
-	// return nodeLister.Get error
+	// return csiNodeLister.Get error
 	return "", err
 }
 

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -692,19 +692,14 @@ func (h *csiHandler) getNodeID(driver string, nodeName string, va *storage.Volum
 			klog.V(4).Infof("Found NodeID %s in CSINode %s", nodeID, nodeName)
 			return nodeID, nil
 		}
-		klog.V(4).Infof("CSINode %s does not contain driver %s", nodeName, driver)
 		// CSINode exists, but does not have the requested driver.
-		// Fall through to Node annotation.
-	} else {
-		// Can't get CSINode, fall through to Node annotation.
-		klog.V(4).Infof("Can't get CSINode %s: %s", nodeName, err)
+		errMessage := fmt.Sprintf("CSINode %s does not contain driver %s", nodeName, driver)
+		klog.V(4).Info(errMessage)
+		return "", errors.New(errMessage)
 	}
 
-	// Check Node annotation.
-	node, err := h.nodeLister.Get(nodeName)
-	if err == nil {
-		return GetNodeIDFromNode(driver, node)
-	}
+	// Can't get CSINode, check Volume Attachment.
+	klog.V(4).Infof("Can't get CSINode %s: %s", nodeName, err)
 
 	// Check VolumeAttachment annotation as the last resort if caller wants so (i.e. has provided one).
 	if va == nil {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/evanphx/json-patch"
-	"k8s.io/api/core/v1"
+	jsonpatch "github.com/evanphx/json-patch"
+	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -93,7 +93,6 @@ func markAsDetached(client kubernetes.Interface, va *storage.VolumeAttachment) (
 
 const (
 	defaultFSType              = "ext4"
-	nodeIDAnnotation           = "csi.volume.kubernetes.io/nodeid"
 	csiVolAttribsAnnotationKey = "csi.volume.kubernetes.io/volume-attributes"
 	vaNodeIDAnnotation         = "csi.alpha.kubernetes.io/node-id"
 )
@@ -112,25 +111,6 @@ func SanitizeDriverName(driver string) string {
 // GetFinalizerName returns Attacher name suitable to be used as finalizer
 func GetFinalizerName(driver string) string {
 	return "external-attacher/" + SanitizeDriverName(driver)
-}
-
-// GetNodeIDFromNode returns nodeID string from node annotations.
-func GetNodeIDFromNode(driver string, node *v1.Node) (string, error) {
-	nodeIDJSON, ok := node.Annotations[nodeIDAnnotation]
-	if !ok {
-		return "", fmt.Errorf("node %q has no NodeID annotation", node.Name)
-	}
-
-	var nodeIDs map[string]string
-	if err := json.Unmarshal([]byte(nodeIDJSON), &nodeIDs); err != nil {
-		return "", fmt.Errorf("cannot parse NodeID annotation on node %q: %s", node.Name, err)
-	}
-	nodeID, ok := nodeIDs[driver]
-	if !ok {
-		return "", fmt.Errorf("cannot find NodeID for driver %q for node %q", driver, node.Name)
-	}
-
-	return nodeID, nil
 }
 
 // GetNodeIDFromCSINode returns nodeID from CSIDriverInfoSpec

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -20,77 +20,12 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
 	driverName = "foo/bar"
 )
-
-func TestGetNodeIDFromNode(t *testing.T) {
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		expectedID  string
-		expectError bool
-	}{
-		{
-			name:        "single key",
-			annotations: map[string]string{"csi.volume.kubernetes.io/nodeid": "{\"foo/bar\": \"MyNodeID\"}"},
-			expectedID:  "MyNodeID",
-			expectError: false,
-		},
-		{
-			name: "multiple keys",
-			annotations: map[string]string{
-				"csi.volume.kubernetes.io/nodeid": "{\"foo/bar\": \"MyNodeID\", \"-foo/bar\": \"MyNodeID2\", \"foo/bar-\": \"MyNodeID3\"}",
-			},
-			expectedID:  "MyNodeID",
-			expectError: false,
-		},
-		{
-			name:        "no annotations",
-			annotations: nil,
-			expectedID:  "",
-			expectError: true,
-		},
-		{
-			name:        "invalid JSON",
-			annotations: map[string]string{"csi.volume.kubernetes.io/nodeid": "\"foo/bar\": \"MyNodeID\""},
-			expectedID:  "",
-			expectError: true,
-		},
-		{
-			name: "annotations for another driver",
-			annotations: map[string]string{
-				"csi.volume.kubernetes.io/nodeid": "{\"-foo/bar\": \"MyNodeID2\", \"foo/bar-\": \"MyNodeID3\"}",
-			},
-			expectedID:  "",
-			expectError: true,
-		},
-	}
-
-	for _, test := range tests {
-		node := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "abc",
-				Annotations: test.annotations,
-			},
-		}
-		nodeID, err := GetNodeIDFromNode(driverName, node)
-
-		if err == nil && test.expectError {
-			t.Errorf("test %s: expected error, got none", test.name)
-		}
-		if err != nil && !test.expectError {
-			t.Errorf("test %s: got error: %s", test.name, err)
-		}
-		if !test.expectError && nodeID != test.expectedID {
-			t.Errorf("test %s: unexpected NodeID: %s", test.name, nodeID)
-		}
-	}
-}
 
 func createBlockCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
 	return &csi.VolumeCapability{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

CSINode is in all supported Kubernetes releases, so no more Node annotation is required.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #203 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Removed usage of annotation csi.volume.kubernetes.io/nodeid on Node objects. The external-attacher now requires Kubernetes 1.14 with feature gate CSINodeInfo enabled.
```
