### PR TITLE
Attacher reacts for deleted PVs if finalizer is present

### DIFF
--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -1198,6 +1198,26 @@ func TestCSIHandler(t *testing.T) {
 			},
 		},
 		{
+			name:           "VA deleted -> PV finalizer removed (GCE PD PV)",
+			initialObjects: []runtime.Object{pvDeleted(gcePDPVWithFinalizer())},
+			deletedVA:      va(false, "", nil),
+			expectedActions: []core.Action{
+				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
+					types.MergePatchType, patch(pvDeleted(gcePDPVWithFinalizer()),
+						pvDeleted(gcePDPV()))),
+			},
+		},
+		{
+			name:           "VA deleted -> PV finalizer not removed",
+			initialObjects: []runtime.Object{pvDeleted(pv())},
+			deletedVA:      va(false, "", nil),
+		},
+		{
+			name:           "VA deleted -> PV finalizer not removed (GCE PD PV)",
+			initialObjects: []runtime.Object{pvDeleted(gcePDPV())},
+			deletedVA:      va(false, "", nil),
+		},
+		{
 			name:           "PV updated -> PV finalizer removed",
 			initialObjects: []runtime.Object{},
 			updatedPV:      pvDeleted(pvWithFinalizer()),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When a `PersistentVolume` gets deleted the external-attacher should consider it in case it has previously added its finalizer to it. Otherwise (for create/update operations), it can continue to only consider it if `.spec.csi != nil`.

**Which issue(s) this PR fixes**:
Fixes #217

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
A bug that prevented the external-attacher from releasing its finalizer from a `PersistentVolume` object that was created using a legacy storage class provisioner has been fixed.
```
