### PR TITLE
Add CHANGELOG for v2.2.0

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -1,0 +1,13 @@
+# Changelog since v2.1.0
+
+### Bug Fixes
+
+- A bug that prevented the external-attacher from releasing its finalizer from a `PersistentVolume` object that was created using a legacy storage class provisioner and migrated to CSI has been fixed. ([#218](https://github.com/kubernetes-csi/external-attacher/pull/218), [@rfranzke](https://github.com/rfranzke))
+- Update package path to v2. Vendoring with dep depends on https://github.com/golang/dep/pull/1963 or the workaround described in v2/README.md. ([#209](https://github.com/kubernetes-csi/external-attacher/pull/209), [@alex1989hu](https://github.com/alex1989hu))
+
+
+### Other Notable Changes
+
+- Removed usage of annotation csi.volume.kubernetes.io/nodeid on Node objects. The external-attacher now requires Kubernetes 1.14 with feature gate CSINodeInfo enabled. ([#213](https://github.com/kubernetes-csi/external-attacher/pull/213), [@Danil-Grigorev](https://github.com/Danil-Grigorev))
+
+

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This information reflects the head of this branch.
 
 | Compatible with CSI Version                                                                | Container Image             | Min K8s Version | Recommended K8s Version |
 | ------------------------------------------------------------------------------------------ | ----------------------------| --------------- | ----------------------- |
-| [CSI Spec v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | quay.io/k8scsi/csi-attacher | 1.15            | 1.17                    |
+| [CSI Spec v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | quay.io/k8scsi/csi-attacher | 1.15            | 1.18                    |
 
 ## Feature Status
 
@@ -31,10 +31,9 @@ The following table reflects the head of this branch.
 
 | Feature       | Status  | Default | Description                                                                                   |
 | ------------- | ------- | ------- | --------------------------------------------------------------------------------------------- |
-| CSINode*      | Beta    | On      | external-attacher uses the CSINode object to get the driver's node name instead of the Node annotation. |
 | CSIMigration* | Beta    | On      | [Migrating in-tree volume plugins to CSI](https://kubernetes.io/docs/concepts/storage/volumes/#csi-migration). |
 
-*) There are no special feature gates for these features. They are enabled by turning on the corresponding features in Kubernetes.
+*) There is no special feature gate for this feature. It is enabled by turning on the corresponding features in Kubernetes.
 
 All other external-attacher features and the external-attacher itself is considered GA and fully supported.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This information reflects the head of this branch.
 
 | Compatible with CSI Version                                                                | Container Image             | Min K8s Version | Recommended K8s Version |
 | ------------------------------------------------------------------------------------------ | ----------------------------| --------------- | ----------------------- |
-| [CSI Spec v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | quay.io/k8scsi/csi-attacher | 1.15            | 1.18                    |
+| [CSI Spec v1.2.0](https://github.com/container-storage-interface/spec/releases/tag/v1.2.0) | quay.io/k8scsi/csi-attacher | 1.14            | 1.18                    |
 
 ## Feature Status
 


### PR DESCRIPTION
/kind documentation

/assign @msau42 

Not sure about min Kubernetes version - now the attacher requires CSINodeInfo. It was beta in 1.14 and GA in 1.17. Can we assume it's enabled in 1.15 or should we raise it to 1.17?

```release-note
NONE
```
