### PR TITLE
Fixes ReconcileVA for non-migratable drivers

### DIFF
--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/workqueue"
-	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog/v2"
 )
 
@@ -178,8 +177,8 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 		}
 
 		// Construct controller
-		csiConnection := &fakeCSIConnection{t: t, calls: test.expectedCSICalls}
 		lister := &fakeLister{t: t, publishedNodes: test.listerResponse}
+		csiConnection := &fakeCSIConnection{t: t, calls: test.expectedCSICalls, lister: lister}
 		handler := handlerFactory(client, informers, csiConnection, lister)
 		ctrl := NewCSIAttachController(client, testAttacherName, handler, vaInformer, pvInformer, workqueue.DefaultControllerRateLimiter(), workqueue.DefaultControllerRateLimiter(), test.listerResponse != nil, 1*time.Minute)
 
@@ -223,6 +222,10 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 				if err != nil {
 					t.Errorf("Failed to reconcile Volume Attachment objects: %v", err)
 				}
+			}
+			if ctrl.vaQueue.Len() > 0 || ctrl.pvQueue.Len() > 0 {
+				// Reconciler created some work, process the queues once again
+				continue
 			}
 			currentActionCount := len(client.Actions())
 			if currentActionCount < len(test.expectedActions) {
@@ -296,6 +299,13 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 
 		if test.additionalCheck != nil {
 			test.additionalCheck(t, test)
+		}
+		// makesure all the csi calls were executed.
+		if csiConnection.index < len(csiConnection.calls) {
+			t.Errorf("Test %q: %d additional expected CSI calls", test.name, len(csiConnection.calls)-csiConnection.index)
+			for _, a := range csiConnection.calls[csiConnection.index:] {
+				t.Logf("   %+v", a)
+			}
 		}
 		klog.Infof("Test %q: finished \n\n", test.name)
 	}
@@ -400,12 +410,25 @@ func (l *fakeLister) ListVolumes(ctx context.Context) (map[string][]string, erro
 	return l.publishedNodes, nil
 }
 
+func (l *fakeLister) Add(volumeHandle string, nodeID string) {
+	if l.publishedNodes != nil {
+		l.publishedNodes[volumeHandle] = []string{nodeID}
+	}
+}
+
+func (l *fakeLister) Delete(volumeHandle string, nodeID string) {
+	if l.publishedNodes != nil {
+		delete(l.publishedNodes, volumeHandle)
+	}
+}
+
 // Fake CSIConnection implementation that check that Attach/Detach is called
 // with the right parameters and it returns proper error code and metadata.
 type fakeCSIConnection struct {
-	calls []csiCall
-	index int
-	t     *testing.T
+	calls  []csiCall
+	index  int
+	lister *fakeLister
+	t      *testing.T
 }
 
 func (f *fakeCSIConnection) GetDriverName(ctx context.Context) (string, error) {
@@ -429,9 +452,12 @@ func (f *fakeCSIConnection) Attach(ctx context.Context, volumeID string, readOnl
 	call := f.calls[f.index]
 	f.index++
 
-	// Force a delay
-	if call.delay != time.Duration(0) {
-		time.Sleep(call.delay)
+	// If caller has set long delay, return when deadline expires
+	select {
+	case <-ctx.Done():
+		return nil, true, ctx.Err()
+	case <-time.After(call.delay):
+		break
 	}
 
 	var err error
@@ -465,6 +491,8 @@ func (f *fakeCSIConnection) Attach(ctx context.Context, volumeID string, readOnl
 	if err != nil {
 		return nil, true, err
 	}
+	// Update the published volume map
+	f.lister.Add(call.volumeHandle, call.nodeID)
 	return call.metadata, call.detached, call.err
 }
 
@@ -476,9 +504,12 @@ func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID 
 	call := f.calls[f.index]
 	f.index++
 
-	// Force a delay
-	if call.delay != time.Duration(0) {
-		time.Sleep(call.delay)
+	// If caller has set long delay, return when deadline expires
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(call.delay):
+		break
 	}
 
 	var err error
@@ -504,6 +535,8 @@ func (f *fakeCSIConnection) Detach(ctx context.Context, volumeID string, nodeID 
 	if err != nil {
 		return err
 	}
+	// Update the published volume map
+	f.lister.Delete(call.volumeHandle, call.nodeID)
 	return call.err
 }
 
@@ -513,18 +546,4 @@ func (f *fakeCSIConnection) Close() error {
 
 func (f *fakeCSIConnection) Probe(timeout time.Duration) error {
 	return nil
-}
-
-// TODO: Remove hardcoding for GCE tests and make more general
-type fakeInTreeToCSITranslator struct{}
-
-func (f fakeInTreeToCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
-	t := csitrans.New()
-	return t.TranslateInTreePVToCSI(pv)
-}
-func (f fakeInTreeToCSITranslator) IsPVMigratable(pv *v1.PersistentVolume) bool {
-	return pv.Spec.GCEPersistentDisk != nil
-}
-func (f fakeInTreeToCSITranslator) RepairVolumeHandle(pluginName, volumeHandle, nodeID string) (string, error) {
-	return volumeHandle, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes an issue in the volume attachment reconciler. Currently, the reconciler calls a method (unconditionally) that is supposed to be called only when the corresponding volume driver implements the in-tree plugin. 
The PR also fixes a few existing broken tests.

**Which issue(s) this PR fixes**:

Fixes #243

**Special notes for your reviewer**:

Tested the fix with csi-mock driver. The driver does not implement in-tree plugin.
Without the fix, the reconciler failed as below:

```
W0806 02:35:26.595059       1 csi_handler.go:159] Failed to repair volume handle  for driver io.kubernetes.storage.mock: could not find In-Tree driver name for CSI plugin io.kubernetes.storage.mock
```

With the fix, no such failure was observed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes an issue that results in a failure in volume attachment reconciler when the corresponding driver does not implement in-tree plugin. 
```
