### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -86,6 +86,12 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
    [external-provisioner example](https://github.com/kubernetes-csi/external-provisioner/releases/new)
 1. If release was a new major/minor version, create a new `release-<minor>`
    branch at that commit.
+1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
+1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
+   the [k8s image
+   repo](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io/images/k8s-staging-sig-storage),
+   run `./generate.sh > images.yaml`, and send a PR with the updated images.
+   Once merged, the image promoter will copy the images from staging to prod.
 1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar
    and feature pages with the new released version.
 1. After all the sidecars have been released, update

--- a/release-tools/travis.yml
+++ b/release-tools/travis.yml
@@ -6,7 +6,7 @@ git:
   depth: false
 matrix:
   include:
-  - go: 1.13.3
+  - go: 1.15
 before_script:
 - mkdir -p bin
 - wget https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -O bin/dep

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,10 +3,13 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.0+incompatible
 github.com/blang/semver
 # github.com/container-storage-interface/spec v1.2.0
+## explicit
 github.com/container-storage-interface/spec/lib/go/csi
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/evanphx/json-patch v4.5.0+incompatible
+## explicit
 github.com/evanphx/json-patch
 # github.com/go-logr/logr v0.2.0
 github.com/go-logr/logr
@@ -16,8 +19,10 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.3
+## explicit
 github.com/golang/mock/gomock
 # github.com/golang/protobuf v1.4.2
+## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go/descriptor
@@ -42,16 +47,19 @@ github.com/googleapis/gnostic/openapiv2
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.9
+## explicit
 github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
 # github.com/kubernetes-csi/csi-lib-utils v0.7.0
+## explicit
 github.com/kubernetes-csi/csi-lib-utils/connection
 github.com/kubernetes-csi/csi-lib-utils/leaderelection
 github.com/kubernetes-csi/csi-lib-utils/metrics
 github.com/kubernetes-csi/csi-lib-utils/protosanitizer
 github.com/kubernetes-csi/csi-lib-utils/rpc
 # github.com/kubernetes-csi/csi-test/v3 v3.1.0
+## explicit
 github.com/kubernetes-csi/csi-test/v3/driver
 github.com/kubernetes-csi/csi-test/v3/utils
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
@@ -113,6 +121,7 @@ google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.28.0
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -192,6 +201,7 @@ gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # k8s.io/api v0.19.0-rc.2
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -234,6 +244,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.19.0-rc.2
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -278,6 +289,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.19.0-rc.2
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/informers
@@ -494,11 +506,13 @@ k8s.io/cloud-provider/volume
 k8s.io/component-base/metrics
 k8s.io/component-base/version
 # k8s.io/csi-translation-lib v0.19.0-rc.2
+## explicit
 k8s.io/csi-translation-lib
 k8s.io/csi-translation-lib/plugins
 # k8s.io/klog v1.0.0
 k8s.io/klog
 # k8s.io/klog/v2 v2.2.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20200427153329-656914f816f9
 k8s.io/kube-openapi/pkg/util/proto
@@ -510,3 +524,23 @@ k8s.io/utils/trace
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.0
+# k8s.io/apiserver => k8s.io/apiserver v0.17.0
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.0
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.0
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.0
+# k8s.io/code-generator => k8s.io/code-generator v0.17.1-beta.0
+# k8s.io/component-base => k8s.io/component-base v0.17.0
+# k8s.io/cri-api => k8s.io/cri-api v0.17.1-beta.0
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.0
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.0
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.0
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.0
+# k8s.io/kubectl => k8s.io/kubectl v0.17.0
+# k8s.io/kubelet => k8s.io/kubelet v0.17.0
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.0
+# k8s.io/metrics => k8s.io/metrics v0.17.0
+# k8s.io/node-api => k8s.io/node-api v0.17.0
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.0
+# k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.17.0
+# k8s.io/sample-controller => k8s.io/sample-controller v0.17.0


### PR DESCRIPTION
Commit summary:
0979c091 prow.sh: fix E2E suite for Kubernetes >= 1.18
3b4a2f1d prow.sh: fix installing Go for Kubernetes 1.19.0
82d108ac switch to Go 1.15
843bddca Add steps on promoting release images

```release-note
build with Go 1.15
```