### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -33,9 +33,9 @@
 # The expected environment is:
 # - $GOPATH/src/<import path> for the repository that is to be tested,
 #   with PR branch merged (when testing a PR)
+# - optional: bazel installed (when testing against Kubernetes master),
+#   must be recent enough for Kubernetes master
 # - running on linux-amd64
-# - bazel installed (when testing against Kubernetes master), must be recent
-#   enough for Kubernetes master
 # - kind (https://github.com/kubernetes-sigs/kind) installed
 # - optional: Go already installed
 
@@ -50,26 +50,6 @@ configvar () {
     # shellcheck disable=SC2140
     eval : \$\{"$1":="\$2"\}
     eval echo "\$3:" "$1=\${$1}"
-}
-
-# Takes the minor version of $CSI_PROW_KUBERNETES_VERSION and overrides it to
-# $1 if they are equal minor versions. Ignores versions that begin with
-# "release-".
-override_k8s_version () {
-    local current_minor_version
-    local override_minor_version
-
-    # Ignore: See if you can use ${variable//search/replace} instead.
-    # shellcheck disable=SC2001
-    current_minor_version="$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/\([0-9]*\)\.\([0-9]*\).*/\1\.\2/')"
-
-    # Ignore: See if you can use ${variable//search/replace} instead.
-    # shellcheck disable=SC2001
-    override_minor_version="$(echo "${1}" | sed -e 's/\([0-9]*\)\.\([0-9]*\).*/\1\.\2/')"
-    if [ "${current_minor_version}" == "${override_minor_version}" ]; then
-      CSI_PROW_KUBERNETES_VERSION="$1"
-      echo "Overriding CSI_PROW_KUBERNETES_VERSION with $1: $CSI_PROW_KUBERNETES_VERSION"
-    fi
 }
 
 # Prints the value of a variable + version suffix, falling back to variable + "LATEST".
@@ -107,9 +87,22 @@ configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version fo
 configvar CSI_PROW_GO_VERSION_GINKGO "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building ginkgo" # depends on CSI_PROW_GINKGO_VERSION below
 
 # kind version to use. If the pre-installed version is different,
-# the desired version is downloaded from https://github.com/kubernetes-sigs/kind/releases/download/
+# the desired version is downloaded from https://github.com/kubernetes-sigs/kind/releases
 # (if available), otherwise it is built from source.
-configvar CSI_PROW_KIND_VERSION "v0.6.0" "kind"
+configvar CSI_PROW_KIND_VERSION "v0.9.0" "kind"
+
+# kind images to use. Must match the kind version.
+# The release notes of each kind release list the supported images.
+configvar CSI_PROW_KIND_IMAGES "kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+kindest/node:v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
+kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
+kindest/node:v1.15.12@sha256:d9b939055c1e852fe3d86955ee24976cab46cba518abcb8b13ba70917e6547a6
+kindest/node:v1.14.10@sha256:ce4355398a704fca68006f8a29f37aafb49f8fc2f64ede3ccd0d9198da910146
+kindest/node:v1.13.12@sha256:1c1a48c2bfcbae4d5f4fa4310b5ed10756facad0b7a2ca93c7a4b5bae5db29f5" "kind images"
+
+# Use kind node-image --type=bazel by default, but allow to disable that.
+configvar CSI_PROW_USE_BAZEL true "use Bazel during 'kind node-image' invocation"
 
 # ginkgo test runner version to use. If the pre-installed version is
 # different, the desired version is built from source.
@@ -124,10 +117,13 @@ configvar CSI_PROW_GINKO_PARALLEL "-p" "Ginko parallelism parameter(s)"
 configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 
 # Kubernetes version to test against. This must be a version number
-# (like 1.13.3) for which there is a pre-built kind image (see
-# https://hub.docker.com/r/kindest/node/tags), "latest" (builds
-# Kubernetes from the master branch) or "release-x.yy" (builds
-# Kubernetes from a release branch).
+# (like 1.13.3), "latest" (builds Kubernetes from the master branch)
+# or "release-x.yy" (builds Kubernetes from a release branch).
+#
+# The patch version is only relevant for picking the E2E test suite
+# that is used for testing. The script automatically picks
+# the kind images for the major/minor version of Kubernetes
+# that the kind release supports.
 #
 # This can also be a version that was not released yet at the time
 # that the settings below were chose. The script will then
@@ -135,16 +131,6 @@ configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 # as long as there are no breaking changes in Kubernetes, like
 # deprecating or changing the implementation of an alpha feature.
 configvar CSI_PROW_KUBERNETES_VERSION 1.17.0 "Kubernetes"
-
-# This is a hack to workaround the issue that each version
-# of kind currently only supports specific patch versions of
-# Kubernetes. We need to override CSI_PROW_KUBERNETES_VERSION
-# passed in by our CI/pull jobs to the versions that
-# kind v0.5.0 supports.
-#
-# If the version is prefixed with "release-", then nothing
-# is overridden.
-override_k8s_version "1.15.3"
 
 # CSI_PROW_KUBERNETES_VERSION reduced to first two version numbers and
 # with underscore (1_13 instead of 1.13.3) and in uppercase (LATEST
@@ -298,11 +284,7 @@ tests_need_alpha_cluster () {
 
 # Regex for non-alpha, feature-tagged tests that should be run.
 #
-# Starting with 1.17, snapshots is beta, but the E2E tests still have the
-# [Feature:] tag. They need to be explicitly enabled.
-configvar CSI_PROW_E2E_FOCUS_1_15 '^' "non-alpha, feature-tagged tests for Kubernetes = 1.15" # no tests to run, match nothing
-configvar CSI_PROW_E2E_FOCUS_1_16 '^' "non-alpha, feature-tagged tests for Kubernetes = 1.16" # no tests to run, match nothing
-configvar CSI_PROW_E2E_FOCUS_LATEST '\[Feature:VolumeSnapshotDataSource\]' "non-alpha, feature-tagged tests for Kubernetes >= 1.17"
+configvar CSI_PROW_E2E_FOCUS_LATEST '\[Feature:VolumeSnapshotDataSource\]' "non-alpha, feature-tagged tests for latest Kubernetes version"
 configvar CSI_PROW_E2E_FOCUS "$(get_versioned_variable CSI_PROW_E2E_FOCUS "${csi_prow_kubernetes_version_suffix}")" "non-alpha, feature-tagged tests"
 
 # Serial vs. parallel is always determined by these regular expressions.
@@ -324,7 +306,7 @@ regex_join () {
 # alpha in previous Kubernetes releases. This was considered too
 # error prone. Therefore we use E2E tests that match the Kubernetes
 # version that is getting tested.
-configvar CSI_PROW_E2E_ALPHA_LATEST '\[Feature:' "alpha tests for Kubernetes >= 1.14" # there's no need to update this, adding a new case for CSI_PROW_E2E for a new Kubernetes is enough
+configvar CSI_PROW_E2E_ALPHA_LATEST '\[Feature:' "alpha tests for latest Kubernetes version" # there's no need to update this, adding a new case for CSI_PROW_E2E for a new Kubernetes is enough
 configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi_prow_kubernetes_version_suffix}")" "alpha tests"
 
 # After the parallel E2E test without alpha features, a test cluster
@@ -339,15 +321,11 @@ configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi
 # kubernetes-csi components must be updated, either by disabling
 # the failing test for "latest" or by updating the test and not running
 # it anymore for older releases.
-configvar CSI_PROW_E2E_ALPHA_GATES_1_15 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for Kubernetes 1.15"
-configvar CSI_PROW_E2E_ALPHA_GATES_1_16 'VolumeSnapshotDataSource=true' "alpha feature gates for Kubernetes 1.16"
-# TODO: add new CSI_PROW_ALPHA_GATES_xxx entry for future Kubernetes releases and
-# add new gates to CSI_PROW_E2E_ALPHA_GATES_LATEST.
-configvar CSI_PROW_E2E_ALPHA_GATES_LATEST '' "alpha feature gates for latest Kubernetes"
+configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'GenericEphemeralVolume=true,CSIStorageCapacity=true' "alpha feature gates for latest Kubernetes"
 configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_GATES "${csi_prow_kubernetes_version_suffix}")" "alpha E2E feature gates"
 
 # Which external-snapshotter tag to use for the snapshotter CRD and snapshot-controller deployment
-configvar CSI_SNAPSHOTTER_VERSION 'v2.0.1' "external-snapshotter version tag"
+configvar CSI_SNAPSHOTTER_VERSION 'v3.0.0' "external-snapshotter version tag"
 
 # Some tests are known to be unusable in a KinD cluster. For example,
 # stopping kubelet with "ssh <node IP> systemctl stop kubelet" simply
@@ -507,6 +485,22 @@ list_gates () (
     done
 )
 
+# Turn feature gates in the format foo=true,bar=false into
+# a YAML map with the corresponding API groups for use
+# with https://kind.sigs.k8s.io/docs/user/configuration/#runtime-config
+list_api_groups () (
+    set -f; IFS=','
+    # Ignore: Double quote to prevent globbing and word splitting.
+    # shellcheck disable=SC2086
+    set -- $1
+    while [ "$1" ]; do
+        if [ "$1" = 'CSIStorageCapacity=true' ]; then
+            echo '   "storage.k8s.io/v1alpha1": "true"'
+        fi
+        shift
+    done
+)
+
 go_version_for_kubernetes () (
     local path="$1"
     local version="$2"
@@ -536,77 +530,51 @@ start_cluster () {
         run kind delete cluster --name=csi-prow || die "kind delete failed"
     fi
 
-    # Build from source?
-    if [[ "${CSI_PROW_KUBERNETES_VERSION}" =~ ^release-|^latest$ ]]; then
+    # Try to find a pre-built kind image if asked to use a specific version.
+    if ! [[ "${CSI_PROW_KUBERNETES_VERSION}" =~ ^release-|^latest$ ]]; then
+        # Ignore: See if you can use ${variable//search/replace} instead.
+        # shellcheck disable=SC2001
+        major_minor=$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/^\([0-9]*\)\.\([0-9]*\).*/\1.\2/')
+        for i in ${CSI_PROW_KIND_IMAGES}; do
+            if echo "$i" | grep -q "kindest/node:v${major_minor}"; then
+                image="$i"
+                break
+            fi
+        done
+    fi
+
+    # Need to build from source?
+    if ! [ "$image" ]; then
         if ! ${csi_prow_kind_have_kubernetes}; then
             local version="${CSI_PROW_KUBERNETES_VERSION}"
             if [ "$version" = "latest" ]; then
                 version=master
             fi
+            if ${CSI_PROW_USE_BAZEL}; then
+                type="bazel"
+            else
+                type="docker"
+            fi
             git_clone_branch https://github.com/kubernetes/kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version" || die "checking out Kubernetes $version failed"
 
             go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
-            run_with_go "$go_version" kind build node-image --type bazel --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes" || die "'kind build node-image' failed"
+            run_with_go "$go_version" kind build node-image --image csiprow/node:latest --type="$type" --kube-root "${CSI_PROW_WORK}/src/kubernetes" || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"
-    else
-        image="kindest/node:v${CSI_PROW_KUBERNETES_VERSION}"
     fi
     cat >"${CSI_PROW_WORK}/kind-config.yaml" <<EOF
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
 - role: worker
-EOF
-
-    # kubeadm has API dependencies between apiVersion and Kubernetes version
-    # 1.15+ requires kubeadm.k8s.io/v1beta2
-    # We only run alpha tests against master so we don't need to maintain
-    # different patches for different Kubernetes releases.
-    if [[ -n "$gates" ]]; then
-        cat >>"${CSI_PROW_WORK}/kind-config.yaml" <<EOF
-kubeadmConfigPatches:
-- |
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: ClusterConfiguration
-  metadata:
-    name: config
-  apiServer:
-    extraArgs:
-      "feature-gates": "$gates"
-  controllerManager:
-    extraArgs:
-      "feature-gates": "$gates"
-  scheduler:
-    extraArgs:
-      "feature-gates": "$gates"
-- |
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: InitConfiguration
-  metadata:
-    name: config
-  nodeRegistration:
-    kubeletExtraArgs:
-      "feature-gates": "$gates"
-- |
-  apiVersion: kubelet.config.k8s.io/v1beta1
-  kind: KubeletConfiguration
-  metadata:
-    name: config
-  featureGates:
+featureGates:
 $(list_gates "$gates")
-- |
-  apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  kind: KubeProxyConfiguration
-  metadata:
-    name: config
-  featureGates:
-$(list_gates "$gates")
+runtimeConfig:
+$(list_api_groups "$gates")
 EOF
-    fi
 
     info "kind-config.yaml:"
     cat "${CSI_PROW_WORK}/kind-config.yaml"
@@ -718,7 +686,7 @@ install_csi_driver () {
 # Installs all nessesary snapshotter CRDs  
 install_snapshot_crds() {
   # Wait until volumesnapshot CRDs are in place.
-  CRD_BASE_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}/config/crd"
+  CRD_BASE_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}/client/config/crd"
   kubectl apply -f "${CRD_BASE_DIR}/snapshot.storage.k8s.io_volumesnapshotclasses.yaml" --validate=false
   kubectl apply -f "${CRD_BASE_DIR}/snapshot.storage.k8s.io_volumesnapshots.yaml" --validate=false
   kubectl apply -f "${CRD_BASE_DIR}/snapshot.storage.k8s.io_volumesnapshotcontents.yaml" --validate=false
@@ -1101,14 +1069,8 @@ main () {
             start_cluster || die "starting the non-alpha cluster failed"
 
             # Install necessary snapshot CRDs and snapshot controller
-            # For Kubernetes 1.17+, we will install the CRDs and snapshot controller.
-            if version_gt "${CSI_PROW_KUBERNETES_VERSION}" "1.16.255" || "${CSI_PROW_KUBERNETES_VERSION}" == "latest"; then
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, installing CRDs and snapshot controller"
-                install_snapshot_crds
-                install_snapshot_controller
-            else
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, skipping CRDs and snapshot controller"
-            fi
+            install_snapshot_crds
+            install_snapshot_controller
 
             # Installing the driver might be disabled.
             if ${CSI_PROW_DRIVER_INSTALL} "$images"; then
@@ -1158,14 +1120,8 @@ main () {
             start_cluster "${CSI_PROW_E2E_ALPHA_GATES}" || die "starting alpha cluster failed"
 
             # Install necessary snapshot CRDs and snapshot controller
-            # For Kubernetes 1.17+, we will install the CRDs and snapshot controller.
-            if version_gt "${CSI_PROW_KUBERNETES_VERSION}" "1.16.255" || "${CSI_PROW_KUBERNETES_VERSION}" == "latest"; then
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, installing CRDs and snapshot controller"
-                install_snapshot_crds
-                install_snapshot_controller
-            else
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, skipping CRDs and snapshot controller"
-            fi
+            install_snapshot_crds
+            install_snapshot_controller
 
             # Installing the driver might be disabled.
             if ${CSI_PROW_DRIVER_INSTALL} "$images"; then


### PR DESCRIPTION
Squashed 'release-tools/' changes from b32dd010..22c0395c

[22c0395c](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395c) Merge pull request #108 from bnrjee/master
[b5b447b5](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b5) Add go ldflags using LDFLAGS at the time of compilation
[16f4afbd](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afbd) Merge pull request #107 from pohly/kind-update
[7bcee13d](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13d) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fbd](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fbd) prow.sh: usage of Bazel optional
[c3afd427](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd427) Merge pull request #104 from xing-yang/snapshot
[dde93b22](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b22) Update to snapshot-controller v3.0.0
[a0f195cc](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195cc) Merge pull request #106 from msau42/fix-canary
[7100c120](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c120) Only set staging registry when running canary job
[b3c65f9c](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9c) Merge pull request #99 from msau42/add-release-process
[e53f3e85](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e85) Merge pull request #103 from msau42/fix-canary
[d1294628](https://github.com/kubernetes-csi/csi-release-tools/commit/d1294628) Document new method for adding CI jobs are new K8s versions
[e73c2ce5](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce5) Use staging registry for canary tests
[2c098465](https://github.com/kubernetes-csi/csi-release-tools/commit/2c098465) Add cleanup instructions to release-notes generation
[60e1cd3d](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3d) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c091](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c091) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1d](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1d) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636c](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636c) Merge pull request #97 from pohly/go-1.15
[82d108ac](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108ac) switch to Go 1.15
[d8a25300](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a25300) Merge pull request #95 from msau42/add-release-process
[843bddca](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddca) Add steps on promoting release images
[0345a835](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a835) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d53](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d53) cloud build: bump timeout in Prow job
[41ec6d15](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d15) Merge pull request #93 from animeshk08/patch-1
[5a54e67d](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67d) filter-junit: Fix gofmt error
[0676fcbd](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcbd) Merge pull request #92 from animeshk08/patch-1
[36ea4ffa](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ffa) filter-junit: Fix golint error
[f5a42037](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a42037) Merge pull request #91 from cyb70289/arm64
[43e50d6f](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6f) prow.sh: enable building arm64 image
[0d5bd843](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd843) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7d](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7d) cloud build: k8s-staging-sig-storage
[c5fd9610](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd9610) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7d](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7d) cloud build: initialize support for running commands in Dockerfile
[be902f40](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f40) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082f](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082f) build.make: optional inclusion of Windows in multiarch images
[5231f05d](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05d) build.make: properly declare push-multiarch
[4569f27a](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27a) build.make: fix push-multiarch ambiguity
[17dde9ef](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9ef) Merge pull request #87 from pohly/cloud-build
[bd416901](https://github.com/kubernetes-csi/csi-release-tools/commit/bd416901) cloud build: initial set of shared files
[9084fecb](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fecb) Merge pull request #81 from msau42/add-release-process
[6f2322e8](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e8) Update patch release notes generation command
[0fcc3b1b](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1b) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fee](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fee) Support local snapshot RBAC for pull jobs
[c1bdf5bf](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5bf) Merge pull request #80 from msau42/add-release-process
[ea1f94aa](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94aa) update release tools instructions
[152396e2](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e2) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc1461](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc1461) Update snapshotter to version 2.0.1
[4cf843f6](https://github.com/kubernetes-csi/csi-release-tools/commit/4cf843f6) Merge pull request #76 from pohly/build-targets
[3863a0f6](https://github.com/kubernetes-csi/csi-release-tools/commit/3863a0f6) build for multiple platforms only in CI, add s390x
[8322a7d0](https://github.com/kubernetes-csi/csi-release-tools/commit/8322a7d0) Merge pull request #72 from pohly/hostpath-update
[7c5a89c8](https://github.com/kubernetes-csi/csi-release-tools/commit/7c5a89c8) prow.sh: use 1.3.0 hostpath driver for testing
[b8587b2b](https://github.com/kubernetes-csi/csi-release-tools/commit/b8587b2b) Merge pull request #71 from wozniakjan/test-vet
[fdb32183](https://github.com/kubernetes-csi/csi-release-tools/commit/fdb32183) Change 'make test-vet' to call 'go vet'
[d717c8c4](https://github.com/kubernetes-csi/csi-release-tools/commit/d717c8c4) Merge pull request #69 from pohly/test-driver-config
[a1432bc9](https://github.com/kubernetes-csi/csi-release-tools/commit/a1432bc9) Merge pull request #70 from pohly/kubelet-feature-gates
[5f74333a](https://github.com/kubernetes-csi/csi-release-tools/commit/5f74333a) prow.sh: also configure feature gates for kubelet
[84f78b12](https://github.com/kubernetes-csi/csi-release-tools/commit/84f78b12) prow.sh: generic driver installation
[3c34b4f2](https://github.com/kubernetes-csi/csi-release-tools/commit/3c34b4f2) Merge pull request #67 from windayski/fix-link
[fa90abd0](https://github.com/kubernetes-csi/csi-release-tools/commit/fa90abd0) fix incorrect link
[ff3cc3f1](https://github.com/kubernetes-csi/csi-release-tools/commit/ff3cc3f1) Merge pull request #54 from msau42/add-release-process
[ac8a0212](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8a0212) Document the process for releasing a new sidecar
[23be6525](https://github.com/kubernetes-csi/csi-release-tools/commit/23be6525) Merge pull request #65 from msau42/update-hostpath
[6582f2ff](https://github.com/kubernetes-csi/csi-release-tools/commit/6582f2ff) Update hostpath driver version to get fix for connection-timeout
[4cc91745](https://github.com/kubernetes-csi/csi-release-tools/commit/4cc91745) Merge pull request #64 from ggriffiths/snapshotter_2_version_update
[8191eab6](https://github.com/kubernetes-csi/csi-release-tools/commit/8191eab6) Update snapshotter to version v2.0.0
[3c463fb1](https://github.com/kubernetes-csi/csi-release-tools/commit/3c463fb1) Merge pull request #61 from msau42/enable-snapshots
[8b0316c7](https://github.com/kubernetes-csi/csi-release-tools/commit/8b0316c7) Fix overriding of junit results by using unique names for each e2e run
[5f444b80](https://github.com/kubernetes-csi/csi-release-tools/commit/5f444b80) Merge pull request #60 from saad-ali/updateHostpathVersion
[af9549b5](https://github.com/kubernetes-csi/csi-release-tools/commit/af9549b5) Update prow hostpath driver version to 1.3.0-rc2
[f6c74b30](https://github.com/kubernetes-csi/csi-release-tools/commit/f6c74b30) Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
[fc809759](https://github.com/kubernetes-csi/csi-release-tools/commit/fc809759) Fix version_gt to work with kubernetes prefix
[9f1f3dd8](https://github.com/kubernetes-csi/csi-release-tools/commit/9f1f3dd8) Merge pull request #56 from msau42/enable-snapshots
[b98b2aed](https://github.com/kubernetes-csi/csi-release-tools/commit/b98b2aed) Enable snapshot tests in 1.17 to be run in non-alpha jobs.
[9ace0204](https://github.com/kubernetes-csi/csi-release-tools/commit/9ace0204) Merge pull request #52 from msau42/update-readme
[540599ba](https://github.com/kubernetes-csi/csi-release-tools/commit/540599ba) Merge pull request #53 from msau42/fix-make
[a4e62996](https://github.com/kubernetes-csi/csi-release-tools/commit/a4e62996) fix syntax for ppc64le build
[771ca6f2](https://github.com/kubernetes-csi/csi-release-tools/commit/771ca6f2) Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
[d7c69d2f](https://github.com/kubernetes-csi/csi-release-tools/commit/d7c69d2f) Merge pull request #51 from msau42/enable-multinode
[4ad69492](https://github.com/kubernetes-csi/csi-release-tools/commit/4ad69492) Improve snapshot pod running checks and improve version_gt
[53888ae7](https://github.com/kubernetes-csi/csi-release-tools/commit/53888ae7) Improve README by adding an explicit Kubernetes dependency section
[9a7a685e](https://github.com/kubernetes-csi/csi-release-tools/commit/9a7a685e) Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
[4ff2f5f0](https://github.com/kubernetes-csi/csi-release-tools/commit/4ff2f5f0) Merge pull request #50 from darkowlzz/kind-0.6.0
[80bba1fe](https://github.com/kubernetes-csi/csi-release-tools/commit/80bba1fe) Use kind v0.6.0
[6d674a7f](https://github.com/kubernetes-csi/csi-release-tools/commit/6d674a7f) Merge pull request #47 from Pensu/multi-arch
[8adde494](https://github.com/kubernetes-csi/csi-release-tools/commit/8adde494) Merge pull request #45 from ggriffiths/snapshot_beta_crds
[003c14b2](https://github.com/kubernetes-csi/csi-release-tools/commit/003c14b2) Add snapshotter CRDs after cluster setup
[a41f3860](https://github.com/kubernetes-csi/csi-release-tools/commit/a41f3860) Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
[1eaaaa1c](https://github.com/kubernetes-csi/csi-release-tools/commit/1eaaaa1c) Delete kind cluster after tests run.
[83a4ef15](https://github.com/kubernetes-csi/csi-release-tools/commit/83a4ef15) Adding build for ppc64le
[4fcafece](https://github.com/kubernetes-csi/csi-release-tools/commit/4fcafece) Merge pull request #43 from pohly/system-pod-logging
[f41c1351](https://github.com/kubernetes-csi/csi-release-tools/commit/f41c1351) prow.sh: also log output of system containers
[ee22a9ca](https://github.com/kubernetes-csi/csi-release-tools/commit/ee22a9ca) Merge pull request #42 from pohly/use-vendor-dir
[80678456](https://github.com/kubernetes-csi/csi-release-tools/commit/80678456) travis.yml: also use vendor directory
[23df4aef](https://github.com/kubernetes-csi/csi-release-tools/commit/23df4aef) prow.sh: use vendor directory if available
[a53bd4c4](https://github.com/kubernetes-csi/csi-release-tools/commit/a53bd4c4) Merge pull request #41 from pohly/go-version
[c8a1c4af](https://github.com/kubernetes-csi/csi-release-tools/commit/c8a1c4af) better handling of Go version
[5e773d2d](https://github.com/kubernetes-csi/csi-release-tools/commit/5e773d2d) update CI to use Go 1.13.3
[f419d745](https://github.com/kubernetes-csi/csi-release-tools/commit/f419d745) Merge pull request #40 from msau42/add-1.16
[e0fde8c4](https://github.com/kubernetes-csi/csi-release-tools/commit/e0fde8c4) Add new variables for 1.16 and remove 1.13
[adf00fea](https://github.com/kubernetes-csi/csi-release-tools/commit/adf00fea) Merge pull request #36 from msau42/full-clone
[f1697d2c](https://github.com/kubernetes-csi/csi-release-tools/commit/f1697d2c) Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
[2c819198](https://github.com/kubernetes-csi/csi-release-tools/commit/2c819198) Merge pull request #34 from pohly/go-mod-tidy
[518d6af6](https://github.com/kubernetes-csi/csi-release-tools/commit/518d6af6) Merge pull request #35 from ddebroy/winbld2
[2d6b3ce8](https://github.com/kubernetes-csi/csi-release-tools/commit/2d6b3ce8) Build Windows only for amd64
[c1078a65](https://github.com/kubernetes-csi/csi-release-tools/commit/c1078a65) go-get-kubernetes.sh: automate Kubernetes dependency handling
[194289aa](https://github.com/kubernetes-csi/csi-release-tools/commit/194289aa) update Go mod support
[0affdf95](https://github.com/kubernetes-csi/csi-release-tools/commit/0affdf95) Merge pull request #33 from gnufied/enable-hostpath-expansion
[6208f6ab](https://github.com/kubernetes-csi/csi-release-tools/commit/6208f6ab) Enable hostpath expansion
[6ecaa76e](https://github.com/kubernetes-csi/csi-release-tools/commit/6ecaa76e) Merge pull request #30 from msau42/fix-windows
[ea2f1b52](https://github.com/kubernetes-csi/csi-release-tools/commit/ea2f1b52) build windows binaries with .exe suffix
[2d335506](https://github.com/kubernetes-csi/csi-release-tools/commit/2d335506) Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
[a8ea8bcc](https://github.com/kubernetes-csi/csi-release-tools/commit/a8ea8bcc) create 2-node kind cluster since topology support is added to hostpath driver
[df8530d9](https://github.com/kubernetes-csi/csi-release-tools/commit/df8530d9) Merge pull request #27 from pohly/dep-vendor-check
[35ceaedc](https://github.com/kubernetes-csi/csi-release-tools/commit/35ceaedc) prow.sh: install dep if needed
[f85ab5af](https://github.com/kubernetes-csi/csi-release-tools/commit/f85ab5af) Merge pull request #26 from ddebroy/windows1
[9fba09b4](https://github.com/kubernetes-csi/csi-release-tools/commit/9fba09b4) Add rule for building Windows binaries
[04008676](https://github.com/kubernetes-csi/csi-release-tools/commit/04008676) Merge pull request #25 from msau42/fix-master-jobs
[dc0a5d83](https://github.com/kubernetes-csi/csi-release-tools/commit/dc0a5d83) Update kind to v0.5.0
[aa85b82c](https://github.com/kubernetes-csi/csi-release-tools/commit/aa85b82c) Merge pull request #23 from msau42/fix-master-jobs
[f46191d9](https://github.com/kubernetes-csi/csi-release-tools/commit/f46191d9) Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
[1cac3af3](https://github.com/kubernetes-csi/csi-release-tools/commit/1cac3af3) Merge pull request #22 from msau42/add-1.15-jobs
[0c0dc300](https://github.com/kubernetes-csi/csi-release-tools/commit/0c0dc300) prow.sh: tag master images with a large version number
[f4f73cef](https://github.com/kubernetes-csi/csi-release-tools/commit/f4f73cef) Merge pull request #21 from msau42/add-1.15-jobs
[4e31f078](https://github.com/kubernetes-csi/csi-release-tools/commit/4e31f078) Change default hostpath driver name to hostpath.csi.k8s.io
[4b6fa4a0](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6fa4a0) Update hostpath version for sidecar testing to v1.2.0-rc2
[ecc79187](https://github.com/kubernetes-csi/csi-release-tools/commit/ecc79187) Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
[a6f21d40](https://github.com/kubernetes-csi/csi-release-tools/commit/a6f21d40) Add variables for 1.15
[db8abb6e](https://github.com/kubernetes-csi/csi-release-tools/commit/db8abb6e) Merge pull request #20 from pohly/test-driver-config
[b2f4e051](https://github.com/kubernetes-csi/csi-release-tools/commit/b2f4e051) prow.sh: flexible test driver config
[03999882](https://github.com/kubernetes-csi/csi-release-tools/commit/03999882) Merge pull request #19 from pohly/go-mod-vendor
[066143d1](https://github.com/kubernetes-csi/csi-release-tools/commit/066143d1) build.make: allow repos to use 'go mod' for vendoring
[0bee7493](https://github.com/kubernetes-csi/csi-release-tools/commit/0bee7493) Merge pull request #18 from pohly/go-version
[e157b6b5](https://github.com/kubernetes-csi/csi-release-tools/commit/e157b6b5) update to Go 1.12.4
[88dc9a47](https://github.com/kubernetes-csi/csi-release-tools/commit/88dc9a47) Merge pull request #17 from pohly/prow
[0fafc663](https://github.com/kubernetes-csi/csi-release-tools/commit/0fafc663) prow.sh: skip sanity testing if component doesn't support it
[bcac1c1f](https://github.com/kubernetes-csi/csi-release-tools/commit/bcac1c1f) Merge pull request #16 from pohly/prow
[0b10f6a4](https://github.com/kubernetes-csi/csi-release-tools/commit/0b10f6a4) prow.sh: update csi-driver-host-path
[0c2677e8](https://github.com/kubernetes-csi/csi-release-tools/commit/0c2677e8) Merge pull request #15 from pengzhisun/master
[ff9bce4a](https://github.com/kubernetes-csi/csi-release-tools/commit/ff9bce4a) Replace 'return' to 'exit' to fix shellcheck error
[c60f3823](https://github.com/kubernetes-csi/csi-release-tools/commit/c60f3823) Merge pull request #14 from pohly/prow
[7aaac225](https://github.com/kubernetes-csi/csi-release-tools/commit/7aaac225) prow.sh: remove AllAlpha=all, part II
[66177736](https://github.com/kubernetes-csi/csi-release-tools/commit/66177736) Merge pull request #13 from pohly/prow
[cda2fc58](https://github.com/kubernetes-csi/csi-release-tools/commit/cda2fc58) prow.sh: avoid AllAlpha=true
[546d5504](https://github.com/kubernetes-csi/csi-release-tools/commit/546d5504) prow.sh: debug failing KinD cluster creation
[9b0d9cd7](https://github.com/kubernetes-csi/csi-release-tools/commit/9b0d9cd7) build.make: skip shellcheck if Docker is not available
[aa45a1cd](https://github.com/kubernetes-csi/csi-release-tools/commit/aa45a1cd) prow.sh: more efficient execution of individual tests
[f3d1d2df](https://github.com/kubernetes-csi/csi-release-tools/commit/f3d1d2df) prow.sh: fix hostpath driver version check
[31dfaf31](https://github.com/kubernetes-csi/csi-release-tools/commit/31dfaf31) prow.sh: fix running of just "alpha" tests
[f5014439](https://github.com/kubernetes-csi/csi-release-tools/commit/f5014439) prow.sh: AllAlpha=true for unknown Kubernetes versions
[95ae9de9](https://github.com/kubernetes-csi/csi-release-tools/commit/95ae9de9) Merge pull request #9 from pohly/prow
[d87eccb4](https://github.com/kubernetes-csi/csi-release-tools/commit/d87eccb4) prow.sh: switch back to upstream csi-driver-host-path
[6602d38b](https://github.com/kubernetes-csi/csi-release-tools/commit/6602d38b) prow.sh: different E2E suite depending on Kubernetes version
[741319bd](https://github.com/kubernetes-csi/csi-release-tools/commit/741319bd) prow.sh: improve building Kubernetes from source
[29545bb0](https://github.com/kubernetes-csi/csi-release-tools/commit/29545bb0) prow.sh: take Go version from Kubernetes source
[429581c5](https://github.com/kubernetes-csi/csi-release-tools/commit/429581c5) prow.sh: pull Go version from travis.yml
[0a0fd49b](https://github.com/kubernetes-csi/csi-release-tools/commit/0a0fd49b) prow.sh: comment clarification
[2069a0af](https://github.com/kubernetes-csi/csi-release-tools/commit/2069a0af) Merge pull request #11 from pohly/verify-shellcheck
[55212ff2](https://github.com/kubernetes-csi/csi-release-tools/commit/55212ff2) initial Prow test job
[6c7ba1be](https://github.com/kubernetes-csi/csi-release-tools/commit/6c7ba1be) build.make: integrate shellcheck into "make test"
[b2d25d4f](https://github.com/kubernetes-csi/csi-release-tools/commit/b2d25d4f) verify-shellcheck.sh: make it usable in csi-release-tools
[3b6af7b1](https://github.com/kubernetes-csi/csi-release-tools/commit/3b6af7b1) Merge pull request #12 from pohly/local-e2e-suite
[104a1ac9](https://github.com/kubernetes-csi/csi-release-tools/commit/104a1ac9) build.make: avoid unit-testing E2E test suite
[34010e75](https://github.com/kubernetes-csi/csi-release-tools/commit/34010e75) Merge pull request #10 from pohly/vendor-check
[e6db50df](https://github.com/kubernetes-csi/csi-release-tools/commit/e6db50df) check vendor directory
[fb13c519](https://github.com/kubernetes-csi/csi-release-tools/commit/fb13c519) verify-shellcheck.sh: import from Kubernetes
[94fc1e31](https://github.com/kubernetes-csi/csi-release-tools/commit/94fc1e31) build.make: avoid unit-testing E2E test suite
[849db0ad](https://github.com/kubernetes-csi/csi-release-tools/commit/849db0ad) Merge pull request #8 from pohly/subtree-check-relax
[cc564f92](https://github.com/kubernetes-csi/csi-release-tools/commit/cc564f92) verify-subtree.sh: relax check and ignore old content
[33d58fdc](https://github.com/kubernetes-csi/csi-release-tools/commit/33d58fdc) Merge pull request #5 from pohly/test-enhancements
[be8a4400](https://github.com/kubernetes-csi/csi-release-tools/commit/be8a4400) Merge pull request #4 from pohly/canary-fix
[b0336b55](https://github.com/kubernetes-csi/csi-release-tools/commit/b0336b55) build.make: more readable "make test" output
[09436b9f](https://github.com/kubernetes-csi/csi-release-tools/commit/09436b9f) build.make: fix pushing of "canary" image from master branch
[147892c9](https://github.com/kubernetes-csi/csi-release-tools/commit/147892c9) build.make: support suppressing checks
[154e33d4](https://github.com/kubernetes-csi/csi-release-tools/commit/154e33d4) build.make: clarify usage of "make V=1"
[3041b8a4](https://github.com/kubernetes-csi/csi-release-tools/commit/3041b8a4) Merge pull request #3 from pohly/verify-subtree
[f28c6b60](https://github.com/kubernetes-csi/csi-release-tools/commit/f28c6b60) test: verify that 'release-tools' subtree is clean
[9132a016](https://github.com/kubernetes-csi/csi-release-tools/commit/9132a016) test: split up into individual targets, run all
[73db4596](https://github.com/kubernetes-csi/csi-release-tools/commit/73db4596) verify-subtree.sh: ensure that there are no local commits
[520a04a7](https://github.com/kubernetes-csi/csi-release-tools/commit/520a04a7) Merge pull request #2 from pohly/repo-fix
[f49080e0](https://github.com/kubernetes-csi/csi-release-tools/commit/f49080e0) README.md: fix repo URL for initial setup

git-subtree-dir: release-tools
git-subtree-split: 22c0395c9cb16a65d47197b405a8cc3cc82fced9

```release-note
NONE
```