### PR TITLE
added labels to the resources to be used for collective operation

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -20,6 +20,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-attacher
+  labels:
+    app: csi-attacher
 spec:
   replicas: 3
   selector:

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -14,6 +14,8 @@ metadata:
   name: csi-attacher
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-attacher
 
 ---
 # Attacher must be able to work with PVs, CSINodes and VolumeAttachments
@@ -21,6 +23,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-attacher-runner
+  labels:
+    app: csi-attacher
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -47,6 +51,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-role
+  labels:
+    app: csi-attacher
 subjects:
   - kind: ServiceAccount
     name: csi-attacher
@@ -65,6 +71,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-attacher
   name: external-attacher-cfg
 rules:
 - apiGroups: ["coordination.k8s.io"]
@@ -78,6 +86,8 @@ metadata:
   name: csi-attacher-role-cfg
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-attacher
 subjects:
   - kind: ServiceAccount
     name: csi-attacher


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
We need to add the common/generic labels to all the resources which are being deployed as the part of any csi driver. It is the part of this [PR](https://github.com/kubernetes-csi/csi-driver-host-path/pull/216)

Special notes for your reviewer:
Since there was no common labels to identify all the items in one set of resources installed, these labels can help us to identify resources and operate on them in a collective manner

Does this PR introduce a user-facing change?:

NONE
