### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/pull-test.sh
+++ b/release-tools/pull-test.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is called by pull Prow jobs for the csi-release-tools
+# repo to ensure that the changes in the PR work when imported into
+# some other repo.
+
+set -ex
+
+# It must be called inside the updated csi-release-tools repo.
+CSI_RELEASE_TOOLS_DIR="$(pwd)"
+
+# Update the other repo.
+cd "$PULL_TEST_REPO_DIR"
+git subtree pull --squash --prefix=release-tools "$CSI_RELEASE_TOOLS_DIR" master
+git log -n2
+
+# Now fall through to testing.
+exec ./.prow.sh


### PR DESCRIPTION
Squashed 'release-tools/' changes from bc0504ad..6616a6b5

[6616a6b5](https://github.com/kubernetes-csi/csi-release-tools/commit/6616a6b5) Merge [pull request #146](https://github.com/kubernetes-csi/csi-release-tools/pull/146) from pohly/kubernetes-1.21
[510fb0f9](https://github.com/kubernetes-csi/csi-release-tools/commit/510fb0f9) prow.sh: support Kubernetes 1.21
[c63c61b3](https://github.com/kubernetes-csi/csi-release-tools/commit/c63c61b3) prow.sh: add CSI_PROW_DEPLOYMENT_SUFFIX
[51ac11c3](https://github.com/kubernetes-csi/csi-release-tools/commit/51ac11c3) Merge [pull request #144](https://github.com/kubernetes-csi/csi-release-tools/pull/144) from pohly/pull-jobs
[dd54c926](https://github.com/kubernetes-csi/csi-release-tools/commit/dd54c926) pull-test.sh: test importing csi-release-tools into other repo
[7d2643a5](https://github.com/kubernetes-csi/csi-release-tools/commit/7d2643a5) Merge [pull request #143](https://github.com/kubernetes-csi/csi-release-tools/pull/143) from pohly/path-setup
[6880b0c8](https://github.com/kubernetes-csi/csi-release-tools/commit/6880b0c8) prow.sh: avoid creating paths unless really running tests

git-subtree-dir: release-tools
git-subtree-split: 6616a6b5294b6df39cfce37f4fce7cdce0a77583

```release-note
NONE
```