### PR TITLE
Panic fix: Handle DeletedFinalStateUnknown in VA deletion

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -168,6 +168,9 @@ func (ctrl *CSIAttachController) vaUpdated(old, new interface{}) {
 
 // vaDeleted reacts to a VolumeAttachment deleted
 func (ctrl *CSIAttachController) vaDeleted(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+		obj = unknown.Obj
+	}
 	va := obj.(*storage.VolumeAttachment)
 	if va != nil && va.Spec.Source.PersistentVolumeName != nil {
 		// Enqueue PV sync event - it will evaluate and remove finalizer


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
external-attacher can panic when there is a DeletedFinalStateUnknown delete event happens. This PR checks the type of obj first before type assert to VA.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that the controller can panic crash when it receives DeletedFinalStateUnknown deletion event.
```

/cc @msau42 @jsafrane