### PR TITLE
reuse same CSI controller client

### DIFF
--- a/pkg/attacher/lister.go
+++ b/pkg/attacher/lister.go
@@ -26,24 +26,22 @@ import (
 )
 
 type CSIVolumeLister struct {
-	conn *grpc.ClientConn
+	client csi.ControllerClient
 }
 
 // NewVolumeLister provides a new VolumeLister object.
 func NewVolumeLister(conn *grpc.ClientConn) *CSIVolumeLister {
 	return &CSIVolumeLister{
-		conn: conn,
+		client: csi.NewControllerClient(conn),
 	}
 }
 
 func (a *CSIVolumeLister) ListVolumes(ctx context.Context) (map[string]([]string), error) {
-	client := csi.NewControllerClient(a.conn)
-
 	p := map[string][]string{}
 
 	tok := ""
 	for {
-		rsp, err := client.ListVolumes(ctx, &csi.ListVolumesRequest{
+		rsp, err := a.client.ListVolumes(ctx, &csi.ListVolumesRequest{
 			StartingToken: tok,
 		})
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Ben Ye <ben.ye@bytedance.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:

Reuse the same CSI controller client. This provides better performance because it is cheaper to not create & gc the client every time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
