### PR TITLE
Fix recommended Kubernetes version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This information reflects the head of this branch.
 
 | Compatible with CSI Version                                                                | Container Image                     | [Min K8s Version](https://kubernetes-csi.github.io/docs/kubernetes-compatibility.html#minimum-version) | [Recommended K8s Version](https://kubernetes-csi.github.io/docs/kubernetes-compatibility.html#recommended-version) |
 | ------------------------------------------------------------------------------------------ | ------------------------------------| ---- | ---- |
-| [CSI Spec v1.5.0](https://github.com/container-storage-interface/spec/releases/tag/v1.5.0) | k8s.gcr.io/sig-storage/csi-attacher | 1.17 | 1.22 |
+| [CSI Spec v1.5.0](https://github.com/container-storage-interface/spec/releases/tag/v1.5.0) | k8s.gcr.io/sig-storage/csi-attacher | 1.17 | 1.17 |
 
 ## Feature Status
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Fixes an issue in the README where the recommended Kubernetes version is set to one higher than it should be.

See for more details:
https://kubernetes-csi.github.io/docs/project-policies.html#recommended-version

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @xing-yang 