### PR TITLE
Clean up unused vars, funcs and types

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -46,8 +46,6 @@ const (
 
 	// Default timeout of short CSI calls like GetPluginInfo
 	csiTimeout = time.Second
-
-	leaderElectionTypeLeases = "leases"
 )
 
 // Command line flags
@@ -81,11 +79,6 @@ var (
 var (
 	version = "unknown"
 )
-
-type leaderElection interface {
-	Run() error
-	WithNamespace(namespace string)
-}
 
 func main() {
 	klog.InitFlags(nil)

--- a/pkg/attacher/attacher.go
+++ b/pkg/attacher/attacher.go
@@ -20,12 +20,10 @@ import (
 	"context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 )
 
 // Attacher implements attach/detach operations against a remote CSI driver.
@@ -82,15 +80,6 @@ func (a *attacher) Detach(ctx context.Context, volumeID string, nodeID string, s
 	}
 
 	_, err := a.client.ControllerUnpublishVolume(ctx, &req)
-	return err
-}
-
-func logGRPC(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	klog.V(5).Infof("GRPC call: %s", method)
-	klog.V(5).Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
-	err := invoker(ctx, method, req, reply, cc, opts...)
-	klog.V(5).Infof("GRPC response: %s", protosanitizer.StripSecrets(reply))
-	klog.V(5).Infof("GRPC error: %v", err)
 	return err
 }
 

--- a/pkg/attacher/attacher_test.go
+++ b/pkg/attacher/attacher_test.go
@@ -36,10 +36,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	driverName = "foo/bar"
-)
-
 type pbMatcher struct {
 	x proto.Message
 }

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -324,15 +324,6 @@ func (h *csiHandler) prepareVANodeID(va *storage.VolumeAttachment, nodeID string
 	return clone, true
 }
 
-func (h *csiHandler) saveVA(va *storage.VolumeAttachment, patch []byte) (*storage.VolumeAttachment, error) {
-	newVA, err := h.client.StorageV1().VolumeAttachments().Patch(context.TODO(), va.Name, types.MergePatchType, patch, metav1.PatchOptions{})
-	if err != nil {
-		return va, err
-	}
-	klog.V(4).Infof("VolumeAttachment %q updated with finalizer and/or NodeID annotation", va.Name)
-	return newVA, nil
-}
-
 func (h *csiHandler) addPVFinalizer(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	finalizerName := GetFinalizerName(h.attacherName)
 	for _, f := range pv.Finalizers {

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -108,9 +108,8 @@ func markAsDetached(client kubernetes.Interface, va *storage.VolumeAttachment) (
 }
 
 const (
-	defaultFSType              = "ext4"
-	csiVolAttribsAnnotationKey = "csi.volume.kubernetes.io/volume-attributes"
-	vaNodeIDAnnotation         = "csi.alpha.kubernetes.io/node-id"
+	defaultFSType      = "ext4"
+	vaNodeIDAnnotation = "csi.alpha.kubernetes.io/node-id"
 )
 
 // SanitizeDriverName sanitizes provided driver name.

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -23,10 +23,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const (
-	driverName = "foo/bar"
-)
-
 func createBlockCapability(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
 	return &csi.VolumeCapability{
 		AccessType: &csi.VolumeCapability_Block{


### PR DESCRIPTION
/kind cleanup

All occurrences reported by the unused linter of golangci-lint.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
