### PR TITLE
Clean up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-release-tools/travis.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/kubernetes-csi/external-attacher.svg?branch=master)](https://travis-ci.org/kubernetes-csi/external-attacher)
-
 # CSI attacher
 
 The external-attacher is a sidecar container that attaches volumes to nodes by calling `ControllerPublish` and `ControllerUnpublish` functions of CSI drivers. It is necessary because internal Attach/Detach controller running in Kubernetes controller-manager does not have any direct interfaces to CSI drivers.


### PR DESCRIPTION
/kind cleanup

Similar to https://github.com/kubernetes-csi/external-provisioner/pull/664

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
