### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -27,7 +27,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
Squashed 'release-tools/' changes from 5489de6e..5b9a1e06

[5b9a1e06](https://github.com/kubernetes-csi/csi-release-tools/commit/5b9a1e06) Merge [pull request #175](https://github.com/kubernetes-csi/csi-release-tools/pull/175) from jimdaga/patch-1
[5eeb6029](https://github.com/kubernetes-csi/csi-release-tools/commit/5eeb6029) images: use k8s-staging-test-infra/gcb-docker-gcloud

git-subtree-dir: release-tools
git-subtree-split: 5b9a1e06794ddb137ff7e2d565416cc6934ec380

```release-note
NONE
```