### PR TITLE
Add TLS support for diagnostics HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ Note that the external-attacher does not scale with more replicas. Only one exte
 
 * `--retry-interval-max`: The exponential backoff maximum value. See [CSI error and timeout handling](#csi-error-and-timeout-handling) for details. 5 minutes is used by default.
 
-* `--http-endpoint`: The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
+* `--http-endpoint`: The TCP network address where the HTTP(S) server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
 
 * `--metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.
+
+* `--http-endpoint-key-file`: The path to TLS key file used for running HTTPS server. The default is empty string, which means that TLS will not be used when running HTTP server. Both `--http-endpoint-key-file` and `--http-endpoint-cert-file` flags must be set to enable TLS support.
+
+* `--http-endpoint-cert-file`: The path to TLS cert file used for running HTTPS server. The default is empty string, which means that TLS will not be used when running HTTP server. Both `--http-endpoint-key-file` and `--http-endpoint-cert-file` flags must be set to enable TLS support.
 
 * `--reconcile-sync`: Resync frequency of the attached volumes with the driver. See [Periodic re-sync](#periodic-re-sync) for details. 1 minute is used by default.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: It adds TLS support for diagnostics HTTP server. In our cluster we require the metrics to be exposed as HTTPS. Not having this support stops us from using metrics from `external-attacher`.

I'm not fully sure about the naming of the flags. I've looked at https://kubernetes.io/docs/setup/best-practices/certificates/ but there isn't seem to be consensus about the flag naming for TLS files. 

**Special notes for your reviewer**: NONE

**Does this PR introduce a user-facing change?**:
```release-note
Add TLS support for diagnostics/metrics/leader election health status HTTP server by adding new flags: `--http-endpoint-key-file` and `--http-endpoint-cert-file`.
```
