### PR TITLE
Skip processing of ManagedFields changes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -291,6 +291,7 @@ func shouldEnqueueVAChange(old, new *storage.VolumeAttachment) bool {
 	sanitized.ResourceVersion = old.ResourceVersion
 	sanitized.Status.AttachError = old.Status.AttachError
 	sanitized.Status.DetachError = old.Status.DetachError
+	sanitized.ManagedFields = old.ManagedFields
 
 	if equality.Semantic.DeepEqual(old, sanitized) {
 		// The objects are the same except Status.Attach/DetachError.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -73,6 +73,19 @@ func TestShouldEnqueueVAChange(t *testing.T) {
 		Time:    metav1.Time{},
 	}
 
+	va2AppendManagedFields := va1.DeepCopy()
+	va2AppendManagedFields.ResourceVersion = "2"
+	va2AppendManagedFields.ManagedFields = append(va2AppendManagedFields.ManagedFields,
+		metav1.ManagedFieldsEntry{
+			APIVersion: "storage.k8s.io/v1beta1",
+			Manager:    "csi-attacher",
+			Operation:  "Update",
+			FieldsType: "FieldsV1",
+			FieldsV1: &metav1.FieldsV1{
+				Raw: []byte(`{"f:metadata":{"f:annotations":{".":{},"f:csi.alpha.kubernetes.io/node-id":{}},"f:finalizers":{".":{},"v:\\\"external-attacher/csi-cdsplugin\\\"":{}}},"f:status":{"f:attached":{},"f:attachmentMetadata":{".":{},"f:devName":{},"f:serial":{}}}}`),
+			},
+		})
+
 	tests := []struct {
 		name           string
 		oldVA, newVA   *storage.VolumeAttachment
@@ -118,6 +131,12 @@ func TestShouldEnqueueVAChange(t *testing.T) {
 			name:           "changed detachError",
 			oldVA:          va1WithDetachError,
 			newVA:          va2ChangedDetachError,
+			expectedResult: false,
+		},
+		{
+			name:           "appended managedFields",
+			oldVA:          va1,
+			newVA:          va2AppendManagedFields,
 			expectedResult: false,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

Respect exponential backoff when attach/detach error occurs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #337

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
