### PR TITLE
release-3.3: update release-tools

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -31,15 +31,7 @@ aliases:
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
-emeritus_approver:
+emeritus_approvers:
 - lpabon
-- sbezverk
-- vladimirvivien
-
-# This documents who previously contributed to Kubernetes-CSI
-# as reviewer.
-emeritus_reviewer:
-- lpabon
-- saad-ali
 - sbezverk
 - vladimirvivien

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -46,10 +46,13 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 ## Release Process
 1. Identify all issues and ongoing PRs that should go into the release, and
   drive them to resolution.
-1. Download v2.8+ [K8s release notes
-  generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
+1. Download the latest version of the
+   [K8s release notes generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
+1. Create a
+   [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+   with `repo:public_repo` access
 1. Generate release notes for the release. Replace arguments with the relevant
-  information.
+   information.
     * Clean up old cached information (also needed if you are generating release
       notes for multiple repos)
       ```bash
@@ -57,15 +60,24 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
       ```
     * For new minor releases on master:
         ```bash
-        GITHUB_TOKEN=<token> release-notes --discover=mergebase-to-latest
-        --github-org=kubernetes-csi --github-repo=external-provisioner
-        --required-author="" --output out.md
+        GITHUB_TOKEN=<token> release-notes \
+          --discover=mergebase-to-latest \
+          --org=kubernetes-csi \
+          --repo=external-provisioner \
+          --required-author="" \
+          --markdown-links \
+          --output out.md
         ```
     * For new patch releases on a release branch:
         ```bash
-        GITHUB_TOKEN=<token> release-notes --discover=patch-to-latest --branch=release-1.1
-        --github-org=kubernetes-csi --github-repo=external-provisioner
-        --required-author="" --output out.md
+        GITHUB_TOKEN=<token> release-notes \
+          --discover=patch-to-latest \
+          --branch=release-1.1 \
+          --org=kubernetes-csi \
+          --repo=external-provisioner \
+          --required-author="" \
+          --markdown-links \
+          --output out.md
         ```
 1. Compare the generated output to the new commits for the release to check if
    any notable change missed a release note.
@@ -99,6 +111,29 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
    CSI hostpath driver with the new sidecars in the [CSI repo](https://github.com/kubernetes-csi/csi-driver-host-path/tree/HEAD/deploy)
    and [k/k
    in-tree](https://github.com/kubernetes/kubernetes/tree/HEAD/test/e2e/testing-manifests/storage-csi/hostpath/hostpath)
+
+### Troubleshooting
+
+#### Image build jobs
+
+The following jobs are triggered after tagging to produce the corresponding
+image(s):
+https://k8s-testgrid.appspot.com/sig-storage-image-build
+
+Clicking on a failed build job opens that job in https://prow.k8s.io. Next to
+the job title is a rerun icon (circle with arrow). Clicking it opens a popup
+with a "rerun" button that maintainers with enough permissions can use. If in
+doubt, ask someone on #sig-release to rerun the job.
+
+Another way to rerun a job is to search for it in https://prow.k8s.io and click
+the rerun icon in the resulting job list:
+https://prow.k8s.io/?job=canary-csi-test-push-images
+
+#### Verify images
+
+Canary and staged images can be viewed at https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage
+
+Promoted images can be viewed at https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/sig-storage
 
 ## Adding support for a new Kubernetes release
 

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -16,9 +16,8 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-# Building three images in external-snapshotter takes roughly half an hour,
-# sometimes more.
-timeout: 3600s
+# Building three images in external-snapshotter takes more than an hour.
+timeout: 7200s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -78,7 +78,7 @@ version_to_git () {
 # the list of windows versions was matched from:
 # - https://hub.docker.com/_/microsoft-windows-nanoserver
 # - https://hub.docker.com/_/microsoft-windows-servercore
-configvar CSI_PROW_BUILD_PLATFORMS "linux amd64; linux ppc64le -ppc64le; linux s390x -s390x; linux arm -arm; linux arm64 -arm64; windows amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 .exe nanoserver:1909 servercore:1909; windows amd64 .exe nanoserver:2004 servercore:2004; windows amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
+configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
 
 # If we have a vendor directory, then use it. We must be careful to only
 # use this for "make" invocations inside the project's repo itself because
@@ -149,7 +149,8 @@ configvar CSI_PROW_KIND_VERSION "$(kind_version_default)" "kind"
 
 # kind images to use. Must match the kind version.
 # The release notes of each kind release list the supported images.
-configvar CSI_PROW_KIND_IMAGES "kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+configvar CSI_PROW_KIND_IMAGES "kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
 kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
 kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
@@ -233,7 +234,7 @@ configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION v4.2.0 "csi-test version"
+configvar CSI_PROW_SANITY_VERSION v4.3.0 "csi-test version"
 configvar CSI_PROW_SANITY_PACKAGE_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"
@@ -736,7 +737,7 @@ install_csi_driver () {
     fi
 }
 
-# Installs all nessesary snapshotter CRDs
+# Installs all necessary snapshotter CRDs
 install_snapshot_crds() {
   # Wait until volumesnapshot CRDs are in place.
   CRD_BASE_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}/client/config/crd"


### PR DESCRIPTION
Squashed 'release-tools/' changes from a6a1a797..335339f0

[335339f0](https://github.com/kubernetes-csi/csi-release-tools/commit/335339f0) Merge [pull request #187](https://github.com/kubernetes-csi/csi-release-tools/pull/187) from mauriciopoppe/remove-eol-windows-versions
[890b87a2](https://github.com/kubernetes-csi/csi-release-tools/commit/890b87a2) Merge [pull request #188](https://github.com/kubernetes-csi/csi-release-tools/pull/188) from pwschuurman/update-release-notes-docs
[274bc9ba](https://github.com/kubernetes-csi/csi-release-tools/commit/274bc9ba) Update Sidecar Release Process documentation to reference latest syntax for release-notes tool
[87b6c372](https://github.com/kubernetes-csi/csi-release-tools/commit/87b6c372) Merge [pull request #185](https://github.com/kubernetes-csi/csi-release-tools/pull/185) from Garima-Negi/fix-OWNERS-files
[f1de2c66](https://github.com/kubernetes-csi/csi-release-tools/commit/f1de2c66) Fix OWNERS file - squashed commits
[59ae38b7](https://github.com/kubernetes-csi/csi-release-tools/commit/59ae38b7) Remove EOL windows versions from BUILD_PLATFORMS
[5d664712](https://github.com/kubernetes-csi/csi-release-tools/commit/5d664712) Merge [pull request #186](https://github.com/kubernetes-csi/csi-release-tools/pull/186) from humblec/sp
[d066f1ba](https://github.com/kubernetes-csi/csi-release-tools/commit/d066f1ba) Correct prow.sh typo and make codespell linter pass
[762e22d0](https://github.com/kubernetes-csi/csi-release-tools/commit/762e22d0) Merge [pull request #184](https://github.com/kubernetes-csi/csi-release-tools/pull/184) from pohly/image-publishing-troubleshooting
[81e26c3f](https://github.com/kubernetes-csi/csi-release-tools/commit/81e26c3f) SIDECAR_RELEASE_PROCESS.md: add troubleshooting for image publishing
[31aa44d1](https://github.com/kubernetes-csi/csi-release-tools/commit/31aa44d1) Merge [pull request #182](https://github.com/kubernetes-csi/csi-release-tools/pull/182) from chrishenzie/csi-sanity-version
[f49e141c](https://github.com/kubernetes-csi/csi-release-tools/commit/f49e141c) Update csi-sanity test suite to v4.3.0
[d9815c28](https://github.com/kubernetes-csi/csi-release-tools/commit/d9815c28) Merge [pull request #181](https://github.com/kubernetes-csi/csi-release-tools/pull/181) from mauriciopoppe/armv7-support
[05c18012](https://github.com/kubernetes-csi/csi-release-tools/commit/05c18012) Add support to build arm/v7 images
[4aedf357](https://github.com/kubernetes-csi/csi-release-tools/commit/4aedf357) Merge [pull request #178](https://github.com/kubernetes-csi/csi-release-tools/pull/178) from xing-yang/timeout
[2b9897eb](https://github.com/kubernetes-csi/csi-release-tools/commit/2b9897eb) Increase build timeout
[51d37029](https://github.com/kubernetes-csi/csi-release-tools/commit/51d37029) Merge [pull request #177](https://github.com/kubernetes-csi/csi-release-tools/pull/177) from mauriciopoppe/kind-image-1.23
[a30efeac](https://github.com/kubernetes-csi/csi-release-tools/commit/a30efeac) Add kind image for 1.23

git-subtree-dir: release-tools
git-subtree-split: 335339f059da0b8b1947794a8c75d9e5b973cb79

```release-note
NONE
```