### PR TITLE
adjust the RBAC to only have PATCH verb

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -69,7 +69,7 @@ metadata:
 rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
+  verbs: ["get", "watch", "list", "delete", "patch", "create"]
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
Considering Update() are replaced by Patch() call, we no longer
need the UPDATE RBAC for the sidecar.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup


```release-note
NONE
```
