### PR TITLE
Change Fstype default to emptyString from ext4

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note that the external-attacher does not scale with more replicas. Only one exte
 
 * `--leader-election-retry-period <duration>`: Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.
 
-* `--default-fstype <type>`: The default filesystem type of the volume to publish. Defaults to `ext4`.
+* `--default-fstype <type>`: The default filesystem type of the volume to publish. Defaults to empty string.
 
 #### Other recognized arguments
 

--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -66,7 +66,7 @@ var (
 	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
 
-	defaultFSType = flag.String("default-fstype", "ext4", "The default filesystem type of the volume to publish.")
+	defaultFSType = flag.String("default-fstype", "", "The default filesystem type of the volume to publish. Defaults to empty string")
 
 	reconcileSync = flag.Duration("reconcile-sync", 1*time.Minute, "Resync interval of the VolumeAttachment reconciler.")
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug



**Which issue(s) this PR fixes**:

Fixes #343 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change Fstype default to emptyString
Action required: CSI drivers that depended on ext4 as the default need to change their deployments to explicitly set ext4.
```
