### PR TITLE
Fix gofmt for go 1.19

### DIFF
--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (


### PR DESCRIPTION
gofmt 1.19 requires an empty line before `package`, otherwise it reformats the license header. Tested with go 1.19.2; rest of the files are fine.

/kind cleanup

```release-note
NONE
```