### PR TITLE
release-3.3: update release-tools

### DIFF
--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -27,6 +27,7 @@ aliases:
   - jingxu97
   - jsafrane
   - pohly
+  - RaunakShah
   - xing-yang
 
 # This documents who previously contributed to Kubernetes-CSI

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.18" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.19" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -121,7 +121,7 @@ configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 # use the same settings as for "latest" Kubernetes. This works
 # as long as there are no breaking changes in Kubernetes, like
 # deprecating or changing the implementation of an alpha feature.
-configvar CSI_PROW_KUBERNETES_VERSION 1.17.0 "Kubernetes"
+configvar CSI_PROW_KUBERNETES_VERSION 1.22.0 "Kubernetes"
 
 # CSI_PROW_KUBERNETES_VERSION reduced to first two version numbers and
 # with underscore (1_13 instead of 1.13.3) and in uppercase (LATEST
@@ -141,7 +141,7 @@ kind_version_default () {
         latest|master)
             echo main;;
         *)
-            echo v0.11.1;;
+            echo v0.14.0;;
     esac
 }
 
@@ -152,16 +152,13 @@ configvar CSI_PROW_KIND_VERSION "$(kind_version_default)" "kind"
 
 # kind images to use. Must match the kind version.
 # The release notes of each kind release list the supported images.
-configvar CSI_PROW_KIND_IMAGES "kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
-kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
-kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
-kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
-kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
-kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
-kindest/node:v1.16.15@sha256:83067ed51bf2a3395b24687094e283a7c7c865ccc12a8b1d7aa673ba0c5e8861
-kindest/node:v1.15.12@sha256:b920920e1eda689d9936dfcf7332701e80be12566999152626b2c9d730397a95
-kindest/node:v1.14.10@sha256:f8a66ef82822ab4f7569e91a5bccaf27bceee135c1457c512e54de8c6f7219f8" "kind images"
+configvar CSI_PROW_KIND_IMAGES "kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
+kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+kindest/node:v1.19.16@sha256:d9c819e8668de8d5030708e484a9fdff44d95ec4675d136ef0a0a584e587f65c
+kindest/node:v1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fcdbd126188e6d7" "kind images"
 
 # By default, this script tests sidecars with the CSI hostpath driver,
 # using the install_csi_driver function. That function depends on
@@ -231,6 +228,9 @@ configvar CSI_PROW_E2E_VERSION "$(version_to_git "${CSI_PROW_KUBERNETES_VERSION}
 configvar CSI_PROW_E2E_REPO "https://github.com/kubernetes/kubernetes" "E2E repo"
 configvar CSI_PROW_E2E_IMPORT_PATH "k8s.io/kubernetes" "E2E package"
 
+# Local path for e2e tests. Set to "none" to disable.
+configvar CSI_PROW_SIDECAR_E2E_IMPORT_PATH "none" "CSI Sidecar E2E package"
+
 # csi-sanity testing from the csi-test repo can be run against the installed
 # CSI driver. For this to work, deploying the driver must expose the Unix domain
 # csi.sock as a TCP service for use by the csi-sanity command, which runs outside
@@ -285,13 +285,18 @@ tests_enabled () {
 sanity_enabled () {
     [ "${CSI_PROW_TESTS_SANITY}" = "sanity" ] && tests_enabled "sanity"
 }
+
+sidecar_tests_enabled () {
+  [ "${CSI_PROW_SIDECAR_E2E_IMPORT_PATH}" != "none" ]
+}
+
 tests_need_kind () {
     tests_enabled "parallel" "serial" "serial-alpha" "parallel-alpha" ||
-        sanity_enabled
+        sanity_enabled || sidecar_tests_enabled
 }
 tests_need_non_alpha_cluster () {
     tests_enabled "parallel" "serial" ||
-        sanity_enabled
+        sanity_enabled || sidecar_tests_enabled
 }
 tests_need_alpha_cluster () {
     tests_enabled "parallel-alpha" "serial-alpha"
@@ -355,12 +360,17 @@ configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_
 configvar CSI_PROW_E2E_GATES_LATEST '' "non alpha feature gates for latest Kubernetes"
 configvar CSI_PROW_E2E_GATES "$(get_versioned_variable CSI_PROW_E2E_GATES "${csi_prow_kubernetes_version_suffix}")" "non alpha E2E feature gates"
 
+# Focus for local tests run in the sidecar E2E repo. Only used if CSI_PROW_SIDECAR_E2E_IMPORT_PATH
+# is not set to "none". If empty, all tests in the sidecar repo will be run.
+configvar CSI_PROW_SIDECAR_E2E_FOCUS '' "tags for local E2E tests"
+configvar CSI_PROW_SIDECAR_E2E_SKIP '' "local tests that need to be skipped"
+
 # Which external-snapshotter tag to use for the snapshotter CRD and snapshot-controller deployment
 default_csi_snapshotter_version () {
 	if [ "${CSI_PROW_KUBERNETES_VERSION}" = "latest" ] || [ "${CSI_PROW_DRIVER_CANARY}" = "canary" ]; then
 		echo "master"
 	else
-		echo "v3.0.2"
+		echo "v4.0.0"
 	fi
 }
 configvar CSI_SNAPSHOTTER_VERSION "$(default_csi_snapshotter_version)" "external-snapshotter version tag"
@@ -371,7 +381,7 @@ configvar CSI_SNAPSHOTTER_VERSION "$(default_csi_snapshotter_version)" "external
 # whether they can run with the current cluster provider, but until
 # they are, we filter them out by name. Like the other test selection
 # variables, this is again a space separated list of regular expressions.
-configvar CSI_PROW_E2E_SKIP 'Disruptive' "tests that need to be skipped"
+configvar CSI_PROW_E2E_SKIP '\[Disruptive\]|\[Feature:SELinux\]' "tests that need to be skipped"
 
 # This creates directories that are required for testing.
 ensure_paths () {
@@ -945,6 +955,9 @@ install_e2e () {
         return
     fi
 
+    if sidecar_tests_enabled; then
+        run_with_go "${CSI_PROW_GO_VERSION_BUILD}" go test -c -o "${CSI_PROW_WORK}/e2e-local.test" "${CSI_PROW_SIDECAR_E2E_IMPORT_PATH}"
+    fi
     git_checkout "${CSI_PROW_E2E_REPO}" "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" "${CSI_PROW_E2E_VERSION}" --depth=1 &&
     if [ "${CSI_PROW_E2E_IMPORT_PATH}" = "k8s.io/kubernetes" ]; then
         patch_kubernetes "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" "${CSI_PROW_WORK}" &&
@@ -1000,8 +1013,13 @@ run_e2e () (
     }
     trap move_junit EXIT
 
-    cd "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" &&
-    run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo -v "$@" "${CSI_PROW_WORK}/e2e.test" -- -report-dir "${ARTIFACTS}" -storage.testdriver="${CSI_PROW_WORK}/test-driver.yaml"
+    if [ "${name}" == "local" ]; then
+        cd "${GOPATH}/src/${CSI_PROW_SIDECAR_E2E_IMPORT_PATH}" &&
+        run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo -v "$@" "${CSI_PROW_WORK}/e2e-local.test" -- -report-dir "${ARTIFACTS}" -report-prefix local
+    else
+        cd "${GOPATH}/src/${CSI_PROW_E2E_IMPORT_PATH}" &&
+        run_with_loggers env KUBECONFIG="$KUBECONFIG" KUBE_TEST_REPO_LIST="$(if [ -e "${CSI_PROW_WORK}/e2e-repo-list" ]; then echo "${CSI_PROW_WORK}/e2e-repo-list"; fi)" ginkgo -v "$@" "${CSI_PROW_WORK}/e2e.test" -- -report-dir "${ARTIFACTS}" -storage.testdriver="${CSI_PROW_WORK}/test-driver.yaml"
+    fi
 )
 
 # Run csi-sanity against installed CSI driver.
@@ -1310,6 +1328,15 @@ main () {
                          -focus="$focus.*($(regex_join "${CSI_PROW_E2E_SERIAL}"))" \
                          -skip="$(regex_join "${CSI_PROW_E2E_ALPHA}" "${CSI_PROW_E2E_SKIP}")"; then
                         warn "E2E serial failed"
+                        ret=1
+                    fi
+                fi
+
+                if sidecar_tests_enabled; then
+                    if ! run_e2e local \
+                         -focus="${CSI_PROW_SIDECAR_E2E_FOCUS}" \
+                         -skip="$(regex_join "${CSI_PROW_E2E_SERIAL}")"; then
+                        warn "E2E sidecar failed"
                         ret=1
                     fi
                 fi


### PR DESCRIPTION
Squashed 'release-tools/' changes from d29a2e75..78c0fb71

[78c0fb71](https://github.com/kubernetes-csi/csi-release-tools/commit/78c0fb71) Merge [pull request #208](https://github.com/kubernetes-csi/csi-release-tools/pull/208) from jsafrane/skip-selinux
[36e433e2](https://github.com/kubernetes-csi/csi-release-tools/commit/36e433e2) Skip SELinux tests in CI by default
[348d4a92](https://github.com/kubernetes-csi/csi-release-tools/commit/348d4a92) Merge [pull request #207](https://github.com/kubernetes-csi/csi-release-tools/pull/207) from RaunakShah/reviewers
[1efc2724](https://github.com/kubernetes-csi/csi-release-tools/commit/1efc2724) Merge [pull request #206](https://github.com/kubernetes-csi/csi-release-tools/pull/206) from RaunakShah/update-prow
[7d410d88](https://github.com/kubernetes-csi/csi-release-tools/commit/7d410d88) Changes to csi prow to run e2e tests in sidecars
[cfa5a75c](https://github.com/kubernetes-csi/csi-release-tools/commit/cfa5a75c) Merge [pull request #203](https://github.com/kubernetes-csi/csi-release-tools/pull/203) from humblec/test-vendor
[4edd1d8a](https://github.com/kubernetes-csi/csi-release-tools/commit/4edd1d8a) Add RaunakShah to CSI reviewers group
[7ccc9594](https://github.com/kubernetes-csi/csi-release-tools/commit/7ccc9594) release tools update to 1.19
[d24254f6](https://github.com/kubernetes-csi/csi-release-tools/commit/d24254f6) Merge [pull request #202](https://github.com/kubernetes-csi/csi-release-tools/pull/202) from xing-yang/kind_0.14.0
[0faa3fc7](https://github.com/kubernetes-csi/csi-release-tools/commit/0faa3fc7) Update to Kind v0.14.0 images
[ef4e1b2b](https://github.com/kubernetes-csi/csi-release-tools/commit/ef4e1b2b) Merge [pull request #201](https://github.com/kubernetes-csi/csi-release-tools/pull/201) from xing-yang/add_1.24_image
[4ddce251](https://github.com/kubernetes-csi/csi-release-tools/commit/4ddce251) Add 1.24 Kind image
[7fe51491](https://github.com/kubernetes-csi/csi-release-tools/commit/7fe51491) Merge [pull request #200](https://github.com/kubernetes-csi/csi-release-tools/pull/200) from pohly/bump-kubernetes-version
[70915a8e](https://github.com/kubernetes-csi/csi-release-tools/commit/70915a8e) prow.sh: update snapshotter version
[31a3f38b](https://github.com/kubernetes-csi/csi-release-tools/commit/31a3f38b) Merge [pull request #199](https://github.com/kubernetes-csi/csi-release-tools/pull/199) from pohly/bump-kubernetes-version
[7577454a](https://github.com/kubernetes-csi/csi-release-tools/commit/7577454a) prow.sh: bump Kubernetes to v1.22.0

git-subtree-dir: release-tools
git-subtree-split: 78c0fb714fa4448b29962a0f34fa18b7b7d97ae6

Fixes https://github.com/kubernetes-csi/csi-driver-host-path/issues/376

```release-note
NONE
```