### PR TITLE
add dependabot github action for auto dependency update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

Additional note for reviewer:

external-provisioner already have this github action.
https://github.com/kubernetes-csi/external-provisioner/blob/master/.github/dependabot.yaml

> /kind cleanup

```release-note
NONE
```
