### PR TITLE
Update CHANGELOG-4.1.md

### DIFF
--- a/CHANGELOG/CHANGELOG-4.1.md
+++ b/CHANGELOG/CHANGELOG-4.1.md
@@ -55,7 +55,6 @@
 - cloud.google.com/go/essentialcontacts: v1.4.0
 - cloud.google.com/go/eventarc: v1.8.0
 - cloud.google.com/go/filestore: v1.4.0
-- cloud.google.com/go/firestore: v1.1.0
 - cloud.google.com/go/functions: v1.9.0
 - cloud.google.com/go/gaming: v1.8.0
 - cloud.google.com/go/gkebackup: v0.3.0
@@ -120,95 +119,22 @@
 - cloud.google.com/go/webrisk: v1.7.0
 - cloud.google.com/go/websecurityscanner: v1.4.0
 - cloud.google.com/go/workflows: v1.9.0
-- github.com/armon/circbuf: [bbbad09](https://github.com/armon/circbuf/tree/bbbad09)
-- github.com/armon/go-metrics: [f0300d1](https://github.com/armon/go-metrics/tree/f0300d1)
-- github.com/armon/go-radix: [7fddfc3](https://github.com/armon/go-radix/tree/7fddfc3)
-- github.com/bgentry/speakeasy: [v0.1.0](https://github.com/bgentry/speakeasy/tree/v0.1.0)
-- github.com/bketelsen/crypt: [5cbc8cc](https://github.com/bketelsen/crypt/tree/5cbc8cc)
-- github.com/blang/semver: [v3.5.1+incompatible](https://github.com/blang/semver/tree/v3.5.1)
 - github.com/buger/jsonparser: [v1.1.1](https://github.com/buger/jsonparser/tree/v1.1.1)
 - github.com/cenkalti/backoff/v4: [v4.1.3](https://github.com/cenkalti/backoff/v4/tree/v4.1.3)
-- github.com/coreos/bbolt: [v1.3.2](https://github.com/coreos/bbolt/tree/v1.3.2)
-- github.com/coreos/etcd: [v3.3.13+incompatible](https://github.com/coreos/etcd/tree/v3.3.13)
-- github.com/coreos/go-semver: [v0.3.0](https://github.com/coreos/go-semver/tree/v0.3.0)
-- github.com/coreos/go-systemd: [95778df](https://github.com/coreos/go-systemd/tree/95778df)
-- github.com/coreos/pkg: [399ea9e](https://github.com/coreos/pkg/tree/399ea9e)
-- github.com/dgrijalva/jwt-go: [v3.2.0+incompatible](https://github.com/dgrijalva/jwt-go/tree/v3.2.0)
-- github.com/dgryski/go-sip13: [e10d5fe](https://github.com/dgryski/go-sip13/tree/e10d5fe)
-- github.com/emicklei/go-restful: [ff4f55a](https://github.com/emicklei/go-restful/tree/ff4f55a)
-- github.com/fatih/color: [v1.7.0](https://github.com/fatih/color/tree/v1.7.0)
 - github.com/flowstack/go-jsonschema: [v0.1.1](https://github.com/flowstack/go-jsonschema/tree/v0.1.1)
-- github.com/form3tech-oss/jwt-go: [v3.2.3+incompatible](https://github.com/form3tech-oss/jwt-go/tree/v3.2.3)
 - github.com/go-logr/stdr: [v1.2.2](https://github.com/go-logr/stdr/tree/v1.2.2)
-- github.com/googleapis/gnostic: [v0.5.5](https://github.com/googleapis/gnostic/tree/v0.5.5)
-- github.com/gopherjs/gopherjs: [0766667](https://github.com/gopherjs/gopherjs/tree/0766667)
-- github.com/grpc-ecosystem/go-grpc-middleware: [v1.0.0](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/v1.0.0)
-- github.com/grpc-ecosystem/go-grpc-prometheus: [v1.2.0](https://github.com/grpc-ecosystem/go-grpc-prometheus/tree/v1.2.0)
 - github.com/grpc-ecosystem/grpc-gateway/v2: [v2.7.0](https://github.com/grpc-ecosystem/grpc-gateway/v2/tree/v2.7.0)
-- github.com/hashicorp/consul/api: [v1.1.0](https://github.com/hashicorp/consul/api/tree/v1.1.0)
-- github.com/hashicorp/consul/sdk: [v0.1.1](https://github.com/hashicorp/consul/sdk/tree/v0.1.1)
-- github.com/hashicorp/errwrap: [v1.0.0](https://github.com/hashicorp/errwrap/tree/v1.0.0)
-- github.com/hashicorp/go-cleanhttp: [v0.5.1](https://github.com/hashicorp/go-cleanhttp/tree/v0.5.1)
-- github.com/hashicorp/go-immutable-radix: [v1.0.0](https://github.com/hashicorp/go-immutable-radix/tree/v1.0.0)
-- github.com/hashicorp/go-msgpack: [v0.5.3](https://github.com/hashicorp/go-msgpack/tree/v0.5.3)
-- github.com/hashicorp/go-multierror: [v1.0.0](https://github.com/hashicorp/go-multierror/tree/v1.0.0)
-- github.com/hashicorp/go-rootcerts: [v1.0.0](https://github.com/hashicorp/go-rootcerts/tree/v1.0.0)
-- github.com/hashicorp/go-sockaddr: [v1.0.0](https://github.com/hashicorp/go-sockaddr/tree/v1.0.0)
-- github.com/hashicorp/go-syslog: [v1.0.0](https://github.com/hashicorp/go-syslog/tree/v1.0.0)
-- github.com/hashicorp/go-uuid: [v1.0.1](https://github.com/hashicorp/go-uuid/tree/v1.0.1)
-- github.com/hashicorp/go.net: [v0.0.1](https://github.com/hashicorp/go.net/tree/v0.0.1)
-- github.com/hashicorp/hcl: [v1.0.0](https://github.com/hashicorp/hcl/tree/v1.0.0)
-- github.com/hashicorp/logutils: [v1.0.0](https://github.com/hashicorp/logutils/tree/v1.0.0)
-- github.com/hashicorp/mdns: [v1.0.0](https://github.com/hashicorp/mdns/tree/v1.0.0)
-- github.com/hashicorp/memberlist: [v0.1.3](https://github.com/hashicorp/memberlist/tree/v0.1.3)
-- github.com/hashicorp/serf: [v0.8.2](https://github.com/hashicorp/serf/tree/v0.8.2)
-- github.com/jonboulle/clockwork: [v0.1.0](https://github.com/jonboulle/clockwork/tree/v0.1.0)
-- github.com/jtolds/gls: [v4.20.0+incompatible](https://github.com/jtolds/gls/tree/v4.20.0)
-- github.com/magiconair/properties: [v1.8.1](https://github.com/magiconair/properties/tree/v1.8.1)
-- github.com/mattn/go-colorable: [v0.0.9](https://github.com/mattn/go-colorable/tree/v0.0.9)
-- github.com/mattn/go-isatty: [v0.0.3](https://github.com/mattn/go-isatty/tree/v0.0.3)
-- github.com/miekg/dns: [v1.0.14](https://github.com/miekg/dns/tree/v1.0.14)
-- github.com/mitchellh/cli: [v1.0.0](https://github.com/mitchellh/cli/tree/v1.0.0)
-- github.com/mitchellh/go-homedir: [v1.1.0](https://github.com/mitchellh/go-homedir/tree/v1.1.0)
-- github.com/mitchellh/go-testing-interface: [v1.0.0](https://github.com/mitchellh/go-testing-interface/tree/v1.0.0)
-- github.com/mitchellh/gox: [v0.4.0](https://github.com/mitchellh/gox/tree/v0.4.0)
-- github.com/mitchellh/iochan: [v1.0.0](https://github.com/mitchellh/iochan/tree/v1.0.0)
-- github.com/oklog/ulid: [v1.3.1](https://github.com/oklog/ulid/tree/v1.3.1)
-- github.com/pascaldekloe/goe: [57f6aae](https://github.com/pascaldekloe/goe/tree/57f6aae)
-- github.com/pelletier/go-toml: [v1.2.0](https://github.com/pelletier/go-toml/tree/v1.2.0)
-- github.com/posener/complete: [v1.1.1](https://github.com/posener/complete/tree/v1.1.1)
-- github.com/prometheus/tsdb: [v0.7.1](https://github.com/prometheus/tsdb/tree/v0.7.1)
-- github.com/ryanuber/columnize: [9b3edd6](https://github.com/ryanuber/columnize/tree/9b3edd6)
-- github.com/sean-/seed: [e2103e2](https://github.com/sean-/seed/tree/e2103e2)
-- github.com/shurcooL/sanitized_anchor_name: [v1.0.0](https://github.com/shurcooL/sanitized_anchor_name/tree/v1.0.0)
-- github.com/smartystreets/assertions: [b2de0cb](https://github.com/smartystreets/assertions/tree/b2de0cb)
-- github.com/smartystreets/goconvey: [v1.6.4](https://github.com/smartystreets/goconvey/tree/v1.6.4)
-- github.com/soheilhy/cmux: [v0.1.4](https://github.com/soheilhy/cmux/tree/v0.1.4)
-- github.com/spf13/cast: [v1.3.0](https://github.com/spf13/cast/tree/v1.3.0)
-- github.com/spf13/jwalterweatherman: [v1.0.0](https://github.com/spf13/jwalterweatherman/tree/v1.0.0)
-- github.com/spf13/viper: [v1.7.0](https://github.com/spf13/viper/tree/v1.7.0)
-- github.com/subosito/gotenv: [v1.2.0](https://github.com/subosito/gotenv/tree/v1.2.0)
-- github.com/tmc/grpc-websocket-proxy: [0ad062e](https://github.com/tmc/grpc-websocket-proxy/tree/0ad062e)
 - github.com/xeipuuv/gojsonpointer: [4e3ac27](https://github.com/xeipuuv/gojsonpointer/tree/4e3ac27)
 - github.com/xeipuuv/gojsonreference: [bd5ef7b](https://github.com/xeipuuv/gojsonreference/tree/bd5ef7b)
 - github.com/xeipuuv/gojsonschema: [v1.2.0](https://github.com/xeipuuv/gojsonschema/tree/v1.2.0)
-- github.com/xiang90/probing: [43a291a](https://github.com/xiang90/probing/tree/43a291a)
-- go.etcd.io/bbolt: v1.3.2
 - go.opentelemetry.io/otel/exporters/otlp/internal/retry: v1.10.0
 - go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc: v1.10.0
 - go.opentelemetry.io/otel/exporters/otlp/otlptrace: v1.10.0
-- gopkg.in/ini.v1: v1.51.0
-- gopkg.in/resty.v1: v1.12.0
 
 ### Changed
 - cloud.google.com/go/bigquery: v1.8.0 → v1.43.0
 - cloud.google.com/go: v0.97.0 → v0.105.0
-- github.com/Azure/go-autorest/autorest/adal: [v0.9.20 → v0.9.13](https://github.com/Azure/go-autorest/autorest/adal/compare/v0.9.20...v0.9.13)
-- github.com/Azure/go-autorest/autorest/mocks: [v0.4.2 → v0.4.1](https://github.com/Azure/go-autorest/autorest/mocks/compare/v0.4.2...v0.4.1)
-- github.com/Azure/go-autorest/autorest: [v0.11.27 → v0.11.18](https://github.com/Azure/go-autorest/autorest/compare/v0.11.27...v0.11.18)
-- github.com/benbjohnson/clock: [v1.1.0 → v1.0.3](https://github.com/benbjohnson/clock/compare/v1.1.0...v1.0.3)
 - github.com/container-storage-interface/spec: [v1.5.0 → v1.7.0](https://github.com/container-storage-interface/spec/compare/v1.5.0...v1.7.0)
-- github.com/cpuguy83/go-md2man/v2: [v2.0.1 → v2.0.0](https://github.com/cpuguy83/go-md2man/v2/compare/v2.0.1...v2.0.0)
 - github.com/emicklei/go-restful/v3: [v3.8.0 → v3.10.0](https://github.com/emicklei/go-restful/v3/compare/v3.8.0...v3.10.0)
 - github.com/evanphx/json-patch: [v4.12.0+incompatible → v5.6.0+incompatible](https://github.com/evanphx/json-patch/compare/v4.12.0...v5.6.0)
 - github.com/felixge/httpsnoop: [v1.0.1 → v1.0.3](https://github.com/felixge/httpsnoop/compare/v1.0.1...v1.0.3)
@@ -224,6 +150,7 @@
 - github.com/googleapis/gax-go/v2: [v2.1.0 → v2.0.5](https://github.com/googleapis/gax-go/v2/compare/v2.1.0...v2.0.5)
 - github.com/imdario/mergo: [v0.3.12 → v0.3.13](https://github.com/imdario/mergo/compare/v0.3.12...v0.3.13)
 - github.com/inconshreveable/mousetrap: [v1.0.0 → v1.0.1](https://github.com/inconshreveable/mousetrap/compare/v1.0.0...v1.0.1)
+- github.com/kubernetes-csi/csi-lib-utils: [v0.11.0 → v0.12.0](https://github.com/kubernetes-csi/csi-lib-utils/compare/v0.11.0...v0.12.0)
 - github.com/kubernetes-csi/csi-test/v4: [v4.0.2 → v4.4.0](https://github.com/kubernetes-csi/csi-test/v4/compare/v4.0.2...v4.4.0)
 - github.com/mailru/easyjson: [v0.7.6 → v0.7.7](https://github.com/mailru/easyjson/compare/v0.7.6...v0.7.7)
 - github.com/matttproud/golang_protobuf_extensions: [v1.0.1 → v1.0.4](https://github.com/matttproud/golang_protobuf_extensions/compare/v1.0.1...v1.0.4)
@@ -235,7 +162,6 @@
 - github.com/prometheus/client_model: [v0.2.0 → v0.3.0](https://github.com/prometheus/client_model/compare/v0.2.0...v0.3.0)
 - github.com/prometheus/common: [v0.32.1 → v0.37.0](https://github.com/prometheus/common/compare/v0.32.1...v0.37.0)
 - github.com/prometheus/procfs: [v0.7.3 → v0.8.0](https://github.com/prometheus/procfs/compare/v0.7.3...v0.8.0)
-- github.com/russross/blackfriday/v2: [v2.1.0 → v2.0.1](https://github.com/russross/blackfriday/v2/compare/v2.1.0...v2.0.1)
 - github.com/spf13/cobra: [v1.4.0 → v1.6.0](https://github.com/spf13/cobra/compare/v1.4.0...v1.6.0)
 - github.com/stretchr/testify: [v1.7.0 → v1.8.0](https://github.com/stretchr/testify/compare/v1.7.0...v1.8.0)
 - github.com/yuin/goldmark: [v1.4.13 → v1.3.5](https://github.com/yuin/goldmark/compare/v1.4.13...v1.3.5)
@@ -247,8 +173,9 @@
 - go.opentelemetry.io/otel: v0.20.0 → v1.10.0
 - go.opentelemetry.io/proto/otlp: v0.7.0 → v0.19.0
 - go.uber.org/goleak: v1.1.10 → v1.2.0
-- golang.org/x/crypto: 3147a52 → 5ea612d
-- golang.org/x/net: a158d28 → 1e63c2f
+- golang.org/x/crypto: 3147a52 → 75b2880
+- golang.org/x/lint: 6edffad → 738671d
+- golang.org/x/net: a158d28 → v0.4.0
 - golang.org/x/oauth2: d3ed0bb → v0.2.0
 - golang.org/x/sync: 886fb93 → 0de741c
 - golang.org/x/sys: 8c9f86f → v0.3.0
@@ -271,11 +198,30 @@
 - sigs.k8s.io/yaml: v1.2.0 → v1.3.0
 
 ### Removed
+- github.com/Azure/go-autorest/autorest/adal: [v0.9.20](https://github.com/Azure/go-autorest/autorest/adal/tree/v0.9.20)
+- github.com/Azure/go-autorest/autorest/date: [v0.3.0](https://github.com/Azure/go-autorest/autorest/date/tree/v0.3.0)
+- github.com/Azure/go-autorest/autorest/mocks: [v0.4.2](https://github.com/Azure/go-autorest/autorest/mocks/tree/v0.4.2)
+- github.com/Azure/go-autorest/autorest: [v0.11.27](https://github.com/Azure/go-autorest/autorest/tree/v0.11.27)
+- github.com/Azure/go-autorest/logger: [v0.2.1](https://github.com/Azure/go-autorest/logger/tree/v0.2.1)
+- github.com/Azure/go-autorest/tracing: [v0.6.0](https://github.com/Azure/go-autorest/tracing/tree/v0.6.0)
+- github.com/Azure/go-autorest: [v14.2.0+incompatible](https://github.com/Azure/go-autorest/tree/v14.2.0)
+- github.com/benbjohnson/clock: [v1.1.0](https://github.com/benbjohnson/clock/tree/v1.1.0)
+- github.com/cpuguy83/go-md2man/v2: [v2.0.1](https://github.com/cpuguy83/go-md2man/v2/tree/v2.0.1)
+- github.com/creack/pty: [v1.1.11](https://github.com/creack/pty/tree/v1.1.11)
 - github.com/getkin/kin-openapi: [v0.76.0](https://github.com/getkin/kin-openapi/tree/v0.76.0)
 - github.com/golang-jwt/jwt/v4: [v4.2.0](https://github.com/golang-jwt/jwt/v4/tree/v4.2.0)
 - github.com/golang/snappy: [v0.0.3](https://github.com/golang/snappy/tree/v0.0.3)
 - github.com/gorilla/mux: [v1.8.0](https://github.com/gorilla/mux/tree/v1.8.0)
+- github.com/gorilla/websocket: [v1.4.2](https://github.com/gorilla/websocket/tree/v1.4.2)
 - github.com/robertkrimen/otto: [c382bd3](https://github.com/robertkrimen/otto/tree/c382bd3)
+- github.com/russross/blackfriday/v2: [v2.1.0](https://github.com/russross/blackfriday/v2/tree/v2.1.0)
+- github.com/spf13/afero: [v1.2.2](https://github.com/spf13/afero/tree/v1.2.2)
+- go.opentelemetry.io/contrib: v0.20.0
+- go.opentelemetry.io/otel/exporters/otlp: v0.20.0
+- go.opentelemetry.io/otel/oteltest: v0.20.0
+- go.opentelemetry.io/otel/sdk/export/metric: v0.20.0
+- go.opentelemetry.io/otel/sdk/metric: v0.20.0
 - google.golang.org/grpc/cmd/protoc-gen-go-grpc: v1.1.0
 - gopkg.in/sourcemap.v1: v1.0.5
 - k8s.io/klog: v1.0.0
+


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation

> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

I ran release note:

```
release-notes \
  --org=kubernetes-csi \
  --repo=external-attacher \
  --start-sha=ebbd25514795655887b775a457f472bdee3607df \
  --end-sha=16347a9b69268edac9b7386c7eb32837b8f1842b \
  --required-author="" \
  --markdown-links \
  --output out.md
```

The following command got the same result.
```
release-notes --discover=mergebase-to-latest \
    --org=kubernetes-csi --repo=external-attacher \
    --required-author="" --output out.md
```

and it updated to the latest change log

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE

```
