### PR TITLE
Add Back Github Groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,14 @@ updates:
       patterns:
         - "k8s.io*"
         - "sigs.k8s.io*" 
+    github-dependencies:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/golang*"
+        - "google.golang.org*"
+        - "k8s.io*"
+        - "sigs.k8s.io*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Add back groups and we can use [dependabot command like ignore](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-version-updates-with-comment-commands) to exclude packages.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
