### PR TITLE
Attacher(fix): prevent panic on nil volume/status in lister

### DIFF
--- a/pkg/attacher/lister.go
+++ b/pkg/attacher/lister.go
@@ -52,7 +52,11 @@ func (a *CSIVolumeLister) ListVolumes(ctx context.Context) (map[string]([]string
 		}
 
 		for _, e := range rsp.Entries {
-			p[e.GetVolume().VolumeId] = e.Status.PublishedNodeIds
+			if e.GetVolume() == nil || e.GetStatus() == nil {
+				continue
+			}
+
+			p[e.GetVolume().VolumeId] = e.GetStatus().GetPublishedNodeIds()
 		}
 		tok = rsp.NextToken
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:

This PR fix the panic in the Lister when a `volume` or `status` is `nil`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #502 

**Special notes for your reviewer**:

Since the `Status` is optional in some case, if status is nil, is it valid to return a key `VolumeId` in map with value `Status` nil?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
