### PR TITLE
Update release tools to fix broken image build pipeline

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -18,6 +18,7 @@ aliases:
   # when they are temporarily unable to review PRs.
   kubernetes-csi-reviewers:
   - andyzhangx
+  - carlory
   - chrishenzie
   - ggriffiths
   - gnufied

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -46,6 +46,9 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 ## Release Process
 1. Identify all issues and ongoing PRs that should go into the release, and
   drive them to resolution.
+1. Update dependencies for sidecars via
+   [go-modules-update.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/HEAD/release-tools/go-modules-update.sh),
+  and get PRs approved and merged.
 1. Check that all [canary CI
   jobs](https://testgrid.k8s.io/sig-storage-csi-ci) are passing,
   and that test coverage is adequate for the changes that are going into the release.

--- a/release-tools/go-modules-update.sh
+++ b/release-tools/go-modules-update.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Usage: go-modules-update.sh
+#
+# Batch update dependencies for sidecars.
+#
+# Required environment variables
+# CSI_RELEASE_TOKEN: Github token needed for generating release notes
+# GITHUB_USER: Github username to create PRs with
+#
+# Instructions:
+# 1. Login with "gh auth login"
+# 2. Copy this script to the kubernetes-csi directory (one directory above the
+# repos)
+# 3. Update the repos and master branch so locally it has the latest upstream
+# change
+# 4. Set environment variables
+# 5. Run script from the kubernetes-csi directory
+#
+# Caveats:
+# - This script doesn't handle interface incompatibility of updates.
+#   You need to resolve interface incompatibility case by case. The
+#   most frequent case is to update the interface(new parameters,  
+#   name change of the method, etc.)in the sidecar repo and make sure
+#   the build and test pass.
+
+
+set -e
+set -x
+
+MAX_RETRY=10
+
+# Get the options
+while getopts ":u:v:" option; do
+   case $option in
+      u) # Set username
+         username=$OPTARG;;
+      v) # Set version
+         v=$OPTARG;;
+     \?) # Invalid option
+         echo "Error: Invalid option: $OPTARG"
+         exit;;
+   esac
+done
+
+# Only need to do this once
+gh auth login
+
+while read -r repo branches; do
+    if [ "$repo" != "#" ]; then
+    (
+        cd "$repo"
+        git fetch origin
+        for i in $branches; do
+            if [ "$(git rev-parse --verify "module-update-$i" 2>/dev/null)" ]; then
+                git checkout master && git branch -d "module-update-$i"
+            fi
+            git checkout -B "module-update-$i" "origin/$i"
+            rm -rf .git/MERGE*
+            if ! git subtree pull --squash --prefix=release-tools https://github.com/kubernetes-csi/csi-release-tools.git master; then
+                # Sometimes "--squash" leads to merge conflicts. Because we know that "release-tools"
+                # is an unmodified copy of csi-release-tools, we can automatically resolve that
+                # by replacing it completely.
+                if [ -e .git/MERGE_MSG ] && [ -e .git/FETCH_HEAD ] && grep -q "^# Conflict" .git/MERGE_MSG; then
+                    rm -rf release-tools
+                    mkdir release-tools
+                    git archive FETCH_HEAD  | tar -C release-tools -xf -
+                    git add release-tools
+                    git commit --file=.git/MERGE_MSG
+                else
+                    exit 1
+                fi
+            fi
+            RETRY=0
+            while ! ./release-tools/go-get-kubernetes.sh -p "$v" && RETRY < $MAX_RETRY
+                do
+                  RETRY=$((RETRY+1))
+                  go mod tidy && go mod vendor && go mod tidy
+            done   
+            go mod tidy && go mod vendor && go mod tidy
+            git add --all
+            git commit -m "Update dependency go modules for k8s v$v"
+            git remote set-url origin "https://github.com/$username/$repo.git"
+            make test
+            git push origin "module-update-$i" --force
+            # Create PR
+prbody=$(cat <<EOF
+Ran kubernetes-csi/csi-release-tools go-get-kubernetes.sh -p ${v}.
+
+
+\`\`\`release-note
+Update kubernetes dependencies to v${v}
+\`\`\`
+EOF
+)
+            gh pr create --title="Update dependency go modules for k8s v$v" --body "$prbody"  --head "$username:module-update-master" --base "master" --repo="kubernetes-csi/$repo"
+        done  
+    )
+    fi
+done <<EOF
+csi-driver-host-path master
+csi-driver-iscsi master
+csi-driver-nfs master
+csi-lib-utils master
+csi-proxy master
+csi-test master
+external-attacher master
+external-health-monitor master
+external-provisioner master
+external-resizer master
+external-snapshotter master
+livenessprobe master
+node-driver-registrar master
+EOF

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.21" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.21.5" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:
Update release tools to fix broken image build pipeline

related to fix: https://github.com/kubernetes-csi/csi-release-tools/issues/245

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
```
Squashed 'release-tools/' changes from f8c8cc4c..b54c1ba4
b54c1ba4 Merge pull request https://github.com/kubernetes-csi/external-attacher/pull/246 from xing-yang/go_1.21
5436c81e Change go version to 1.21.5
267b40e9 Merge pull request https://github.com/kubernetes-csi/external-attacher/pull/244 from carlory/sig-storage
b42e5a2d nominate self (carlory) as kubernetes-csi reviewer
a17f536f Merge pull request https://github.com/kubernetes-csi/external-attacher/pull/210 from sunnylovestiramisu/sidecar
011033de Use set -x instead of die
5deaf667 Add wrapper script for sidecar release

git-subtree-dir: release-tools
git-subtree-split: b54c1ba49469d4d5d1b5d75285e8868ffe3d328f
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
