### PR TITLE
Sync dependabot config from external-provisioner

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,25 +3,27 @@ enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
   directory: "/"
+  allow:
+  - dependency-type: "all"
   schedule:
     interval: weekly
   groups:
     golang-dependencies:
       patterns:
         - "github.com/golang*"
-        - "google.golang.org*"
     k8s-dependencies:
       patterns:
         - "k8s.io*"
-        - "sigs.k8s.io*" 
+        - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
     github-dependencies:
       patterns:
         - "*"
       exclude-patterns:
         - "github.com/golang*"
-        - "google.golang.org*"
         - "k8s.io*"
         - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
In the external-provisioner repo we experimented with updating *all* dependencies instead of the explicitly required ones. IMHO it is useful, I'm syncing it to all sidecars.

```release-note
NONE
```
