### PR TITLE
Prow update master

### DIFF
--- a/release-tools/pull-test.sh
+++ b/release-tools/pull-test.sh
@@ -20,6 +20,11 @@
 
 set -ex
 
+# Prow checks out repos with --filter=blob:none. This breaks
+# "git subtree pull" unless we enable fetching missing file content.
+GIT_NO_LAZY_FETCH=0
+export GIT_NO_LAZY_FETCH
+
 # It must be called inside the updated csi-release-tools repo.
 CSI_RELEASE_TOOLS_DIR="$(pwd)"
 


### PR DESCRIPTION
/kind cleanup

Update release-tools according to https://github.com/kubernetes-csi/csi-release-tools/issues/7

Squashed 'release-tools/' changes from 227577e0..734c2b95

[734c2b95](https://github.com/kubernetes-csi/csi-release-tools/commit/734c2b95) Merge [pull request #265](https://github.com/kubernetes-csi/csi-release-tools/pull/265) from Rakshith-R/consider-main-branch
[f95c855b](https://github.com/kubernetes-csi/csi-release-tools/commit/f95c855b) Merge [pull request #262](https://github.com/kubernetes-csi/csi-release-tools/pull/262) from huww98/golang-toolchain
[3c8d966f](https://github.com/kubernetes-csi/csi-release-tools/commit/3c8d966f) Treat main branch as equivalent to master branch
[e31de525](https://github.com/kubernetes-csi/csi-release-tools/commit/e31de525) Merge [pull request #261](https://github.com/kubernetes-csi/csi-release-tools/pull/261) from huww98/golang
[fd153a9e](https://github.com/kubernetes-csi/csi-release-tools/commit/fd153a9e) Bump golang to 1.23.1
[a8b3d050](https://github.com/kubernetes-csi/csi-release-tools/commit/a8b3d050) pull-test.sh: fix "git subtree pull" errors
[6b05f0fc](https://github.com/kubernetes-csi/csi-release-tools/commit/6b05f0fc) use new GOTOOLCHAIN env to manage go version

git-subtree-dir: release-tools
git-subtree-split: 734c2b950c4b31f64b63052c64ffa5929d1c9b97

```release-note
NONE
```
