### PR TITLE
Separate attacher flags into attacher only flags and global shared flags

### DIFF
--- a/cmd/csi-attacher/config/flags.go
+++ b/cmd/csi-attacher/config/flags.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"flag"
+	"time"
+)
+
+type AttacherConfiguration struct {
+	MaxEntries         int
+	ReconcileSync      time.Duration
+	MaxGRPCLogLength   int
+	WorkerThreads      int
+	DefaultFSType      string
+	Timeout            time.Duration
+	RetryIntervalStart time.Duration
+	RetryIntervalMax   time.Duration
+}
+
+func registerAttacherFlags(flags *flag.FlagSet, configuration *AttacherConfiguration, prefix string) {
+	flag.IntVar(&configuration.MaxEntries, prefix+"max-entries", 0, "Max entries per each page in volume lister call, 0 means no limit.")
+	flag.DurationVar(&configuration.ReconcileSync, prefix+"reconcile-sync", 1*time.Minute, "Resync interval of the VolumeAttachment reconciler.")
+	flag.IntVar(&configuration.MaxGRPCLogLength, prefix+"max-grpc-log-length", -1, "The maximum amount of characters logged for every grpc responses. Defaults to no limit")
+	flags.IntVar(&configuration.WorkerThreads, prefix+"worker-threads", 10, "Number of worker threads per sidecar")
+	flags.StringVar(&configuration.DefaultFSType, prefix+"default-fstype", "", "The default filesystem type of the volume to use.")
+	flags.DurationVar(&configuration.Timeout, prefix+"timeout", 15*time.Second, "Timeout for waiting for attaching or detaching the volume.")
+	flags.DurationVar(&configuration.RetryIntervalStart, prefix+"retry-interval-start", time.Second, "Initial retry interval of failed create volume or deletion. It doubles with each failure, up to retry-interval-max.")
+	flags.DurationVar(&configuration.RetryIntervalMax, prefix+"retry-interval-max", 5*time.Minute, "Maximum retry interval of failed create volume or deletion.")
+}
+
+// RegisterAttacherFlags registers attacher only flags.
+func RegisterAttacherFlags(flags *flag.FlagSet, configuration *AttacherConfiguration) {
+	registerAttacherFlags(flags, configuration, "")
+}
+
+// RegisterAttacherFlagsWithPrefix registers attacher only flags with the prefix attacher-.
+func RegisterAttacherFlagsWithPrefix(flags *flag.FlagSet, configuration *AttacherConfiguration) {
+	registerAttacherFlags(flags, configuration, "attacher-")
+}

--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 	"github.com/kubernetes-csi/csi-lib-utils/standardflags"
+	"github.com/kubernetes-csi/external-attacher/cmd/csi-attacher/config"
 	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
 	"github.com/kubernetes-csi/external-attacher/pkg/controller"
 	"github.com/kubernetes-csi/external-attacher/pkg/features"
@@ -65,26 +66,17 @@ const (
 
 // Command line flags
 var (
-	kubeconfig    = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
-	resync        = flag.Duration("resync", 10*time.Minute, "Resync interval of the controller.")
-	csiAddress    = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
-	showVersion   = flag.Bool("version", false, "Show version.")
-	timeout       = flag.Duration("timeout", 15*time.Second, "Timeout for waiting for attaching or detaching the volume.")
-	workerThreads = flag.Uint("worker-threads", 10, "Number of attacher worker threads")
-	maxEntries    = flag.Int("max-entries", 0, "Max entries per each page in volume lister call, 0 means no limit.")
-
-	retryIntervalStart = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed create volume or deletion. It doubles with each failure, up to retry-interval-max.")
-	retryIntervalMax   = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed create volume or deletion.")
+	kubeconfig  = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Required only when running out of cluster.")
+	resync      = flag.Duration("resync", 10*time.Minute, "Resync interval of the controller.")
+	csiAddress  = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
+	showVersion = flag.Bool("version", false, "Show version.")
+	timeout     = flag.Duration("timeout", 15*time.Second, "Timeout for waiting for attaching or detaching the volume.")
 
 	enableLeaderElection        = flag.Bool("leader-election", false, "Enable leader election.")
 	leaderElectionNamespace     = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
 	leaderElectionLeaseDuration = flag.Duration("leader-election-lease-duration", 15*time.Second, "Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds.")
 	leaderElectionRenewDeadline = flag.Duration("leader-election-renew-deadline", 10*time.Second, "Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds.")
 	leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
-
-	defaultFSType = flag.String("default-fstype", "", "The default filesystem type of the volume to publish. Defaults to empty string")
-
-	reconcileSync = flag.Duration("reconcile-sync", 1*time.Minute, "Resync interval of the VolumeAttachment reconciler.")
 
 	metricsAddress = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
 	httpEndpoint   = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080`). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.")
@@ -93,14 +85,12 @@ var (
 	kubeAPIQPS   = flag.Float64("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
 	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
 
-	maxGRPCLogLength = flag.Int("max-grpc-log-length", -1, "The maximum amount of characters logged for every grpc responses. Defaults to no limit")
-
 	featureGates map[string]bool
 )
 
-var (
-	version = "unknown"
-)
+var version = "unknown"
+
+var attacherConfiguration = config.AttacherConfiguration{}
 
 func main() {
 	flag.Var(utilflag.NewMapStringBool(&featureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
@@ -110,9 +100,21 @@ func main() {
 	logsapi.AddFeatureGates(fg)
 	c := logsapi.NewLoggingConfiguration()
 	logsapi.AddGoFlags(c, flag.CommandLine)
+	config.RegisterAttacherFlags(flag.CommandLine, &attacherConfiguration)
 	logs.InitLogs()
 	standardflags.AddAutomaxprocs(klog.Infof)
 	flag.Parse()
+
+	// Make AttacherConfiguration values visible as local variables.
+	defaultFSType := &attacherConfiguration.DefaultFSType
+	workerThreads := &attacherConfiguration.WorkerThreads
+	timeout := &attacherConfiguration.Timeout
+	reconcileSync := &attacherConfiguration.ReconcileSync
+	maxGRPCLogLength := &attacherConfiguration.MaxGRPCLogLength
+	maxEntries := &attacherConfiguration.MaxEntries
+	retryIntervalStart := &attacherConfiguration.RetryIntervalStart
+	retryIntervalMax := &attacherConfiguration.RetryIntervalMax
+
 	logger := klog.Background()
 	if err := logsapi.ValidateAndApply(c, fg); err != nil {
 		logger.Error(err, "LoggingConfiguration is invalid")


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind design

**What this PR does / why we need it**:
Split attacher flags into attacher only flags and global flags.

We're moving some of the flags into its own package so that the flags can be imported by `external-attacher` and by other repositories. We're doing this to prepare external-attacher for its integration with the CSI Sidecar monorepo.

Testing:

- Within this repo there's no op besides checking that it builds fine.
- In the CSI Sidecar monorepo we should be able to import the new `cmd/config` package and reuse the exported functions and types. The CSI Sidecar monorepo will use the function `RegisterAttacherFlagsWithPrefix` so that the attacher flags are imported with the `attacher-` prefix.

In the CSI Sidecar monorepo the change to adopt this is https://github.com/mauriciopoppe/csi-sidecars-aio-poc/pull/11. 

After compiling the CSI Sidecar monorepo binary the output for its help is:

```
+ ./bin/csi-sidecars --help
Usage of ./bin/csi-sidecars:
      --add_dir_header                                    If true, adds the file directory to the header of the log messages
      --alsologtostderr                                   log to standard error as well as files (no effect when -logtostderr=true)
      --attacher-default-fstype string                    The default filesystem type of the volume to use.
      --attacher-max-entries int                          Max entries per each page in volume lister call, 0 means no limit.
      --attacher-max-grpc-log-length int                  The maximum amount of characters logged for every grpc responses. Defaults to no limit (default -1)
      --attacher-reconcile-sync duration                  Resync interval of the VolumeAttachment reconciler. (default 1m0s)
      --attacher-retry-interval-max duration              Maximum retry interval of failed create volume or deletion. (default 5m0s)
      --attacher-retry-interval-start duration            Initial retry interval of failed create volume or deletion. It doubles with each failure, up to retry-interval-max. (default 1s)
      --attacher-timeout duration                         Timeout for waiting for attaching or detaching the volume. (default 15s)
      --attacher-worker-threads int                       Number of worker threads per sidecar (default 10)
```

For more info please read https://docs.google.com/document/d/1AKqJeAlBL8PkH8D9zABCZ82Bk1N46EygKPvVh5p4-qU/edit?tab=t.0.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @jsafrane @xing-yang @mowangdk @ConnorJC3 