### PR TITLE
Update release tools

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -19,7 +19,6 @@ aliases:
   kubernetes-csi-reviewers:
   - andyzhangx
   - carlory
-  - chrishenzie
   - ggriffiths
   - gnufied
   - humblec

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.24.2" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.24.6" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -199,7 +199,7 @@ kindest/node:v1.26.15@sha256:c79602a44b4056d7e48dc20f7504350f1e87530fe953428b792
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.15.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.17.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"


### PR DESCRIPTION
/kind cleanup

Squashed 'release-tools/' changes from 0a435bf9..5f38a907

5f38a907 Merge pull request #282 from rhrmo/update-go-1.24.6
579f6242 Update go to 1.24.6
74e066a8 Merge pull request #279 from Aishwarya-Hebbar/update-csi-prow-version
6f236be7 Update CSI prow driver version to v1.17.0
0ee55894 Merge pull request #280 from xing-yang/update_go_1.24.4
9af10153 update to go 1.24.4
f5fec3e3 Merge pull request #275 from chrishenzie/emeritus
c5d285db Remove chrishenzie from kubernetes-csi-reviewers

git-subtree-dir: release-tools
git-subtree-split: 5f38a907597230563f5e2213aea116acdd9d86bc

```release-note
NONE
```
