### PR TITLE
Bump toolchain to go1.24.6 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubernetes-csi/external-attacher
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.6
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Follow up to https://github.com/kubernetes-csi/external-attacher/pull/678 to bump the go toolchain to 1.24.6 to make it consistent with the version used for kubernetes 1.34.0 and the other sidecars.

**Special notes for your reviewer**:

/cc @jsafrane

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
