### PR TITLE
Graduate MutableCSINodeAllocatableCount feature gate to GA

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -26,6 +26,7 @@ const (
 	// kep: https://kep.k8s.io/4876
 	// alpha: v1.33
 	// beta: v1.34
+	// stable: v1.36
 	//
 	// Makes CSINode.Spec.Drivers[*].Allocatable.Count mutable, allowing CSI drivers to
 	// update the number of volumes that can be allocated on a node. Additionally, enables
@@ -47,5 +48,5 @@ func init() {
 // To add a new feature, define a key for it above and add it here.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ReleaseLeaderElectionOnExit:    {Default: false, PreRelease: featuregate.Alpha},
-	MutableCSINodeAllocatableCount: {Default: false, PreRelease: featuregate.Beta},
+	MutableCSINodeAllocatableCount: {Default: true, PreRelease: featuregate.GA},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:

This PR updates enables `MutableCSINodeAllocatableCount` by default and graduates it to GA.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Feature gate is already enabled by default in kube-apiserver and kubelet.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Promote MutableCSINodeAllocatableCount feature to GA.
```
