### PR TITLE
Update the module import path to include /v4

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -51,9 +51,9 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 	"github.com/kubernetes-csi/csi-lib-utils/standardflags"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
-	"github.com/kubernetes-csi/external-attacher/pkg/controller"
-	"github.com/kubernetes-csi/external-attacher/pkg/features"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/controller"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/features"
 	"google.golang.org/grpc"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kubernetes-csi/external-attacher
+module github.com/kubernetes-csi/external-attacher/v4
 
 go 1.25.5
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/features"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/features"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/kubernetes-csi/csi-lib-utils/connection"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
-	"github.com/kubernetes-csi/external-attacher/pkg/features"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/features"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -26,8 +26,8 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/kubernetes-csi/csi-lib-utils/connection"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
-	"github.com/kubernetes-csi/external-attacher/pkg/features"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/features"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/attacher"
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"

--- a/pkg/controller/trivial_handler_test.go
+++ b/pkg/controller/trivial_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kubernetes-csi/external-attacher/pkg/attacher"
+	"github.com/kubernetes-csi/external-attacher/v4/pkg/attacher"
 
 	storage "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

To respect go versioning and have the module import-able.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #645

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed the module path to include `/v4`.
```
