### PR TITLE
Use rfc 6902 with finalizers

### DIFF
--- a/pkg/controller/csi_handler.go
+++ b/pkg/controller/csi_handler.go
@@ -343,17 +343,17 @@ func (h *csiHandler) addPVFinalizer(ctx context.Context, pv *v1.PersistentVolume
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "PersistentVolume", pv.Name)
 	finalizerName := GetFinalizerName(h.attacherName)
 	if slices.Contains(pv.Finalizers, finalizerName) {
-		// Finalizer is already present
 		logger.V(4).Info("PersistentVolume finalizer is already set")
 		return pv, nil
 	}
 
-	// Finalizer is not present, add it
 	logger.V(4).Info("Adding finalizer to PersistentVolume")
-	clone := pv.DeepCopy()
-	clone.Finalizers = append(clone.Finalizers, finalizerName)
+	patch, err := addFinalizerPatch(pv.Finalizers, finalizerName)
+	if err != nil {
+		return pv, fmt.Errorf("failed to create add-finalizer patch: %w", err)
+	}
 
-	newPV, err := h.patchPV(ctx, pv, clone)
+	newPV, err := h.client.CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return pv, err
 	}
@@ -704,22 +704,14 @@ func (h *csiHandler) SyncNewOrUpdatedPersistentVolume(ctx context.Context, pv *v
 	}
 	// No VA found -> remove finalizer
 	logger.V(4).Info("CSIHandler: processing PersistentVolume: no VolumeAttachment found, removing finalizer")
-	clone := pv.DeepCopy()
-	newFinalizers := []string{}
-	for _, f := range pv.Finalizers {
-		if f == finalizer {
-			continue
-		}
-		newFinalizers = append(newFinalizers, f)
+	patch, err := removeFinalizerPatch(pv.Finalizers, finalizer)
+	if err != nil {
+		logger.Error(err, "Failed to create remove-finalizer patch for PersistentVolume")
+		h.pvQueue.AddRateLimited(pv.Name)
+		return
 	}
-	if len(newFinalizers) == 0 {
-		// Canonize empty finalizers for unit test (so we don't need to
-		// distinguish nil and [] there)
-		newFinalizers = nil
-	}
-	clone.Finalizers = newFinalizers
 
-	if _, err = h.patchPV(ctx, pv, clone); err != nil {
+	if _, err = h.client.CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.JSONPatchType, patch, metav1.PatchOptions{}); err != nil {
 		logger.Error(err, "Failed to remove finalizer from PersistentVolume")
 		h.pvQueue.AddRateLimited(pv.Name)
 		return
@@ -794,19 +786,6 @@ func (h *csiHandler) patchVA(ctx context.Context, va, clone *storage.VolumeAttac
 		return va, err
 	}
 	return newVa, nil
-}
-
-func (h *csiHandler) patchPV(ctx context.Context, pv, clone *v1.PersistentVolume) (*v1.PersistentVolume, error) {
-	patch, err := createMergePatch(pv, clone)
-	if err != nil {
-		return pv, err
-	}
-
-	newPV, err := h.client.CoreV1().PersistentVolumes().Patch(ctx, pv.Name, types.MergePatchType, patch, metav1.PatchOptions{})
-	if err != nil {
-		return pv, err
-	}
-	return newPV, nil
 }
 
 func markAsMigrated(parent context.Context, hasMigrated bool) context.Context {

--- a/pkg/controller/csi_handler_test.go
+++ b/pkg/controller/csi_handler_test.go
@@ -266,6 +266,24 @@ func patch(original, new any) []byte {
 	return patch
 }
 
+func pvAddFinalizerJSON(pv *v1.PersistentVolume) []byte {
+	p, err := addFinalizerPatch(pv.Finalizers, fin)
+	if err != nil {
+		klog.Background().Error(err, "Failed to create add-finalizer patch")
+		return nil
+	}
+	return p
+}
+
+func pvRemoveFinalizerJSON(pv *v1.PersistentVolume) []byte {
+	p, err := removeFinalizerPatch(pv.Finalizers, fin)
+	if err != nil {
+		klog.Background().Error(err, "Failed to create remove-finalizer patch")
+		return nil
+	}
+	return p
+}
+
 func vaWithAttachErrorAndCode(va *storage.VolumeAttachment, message string, code codes.Code) *storage.VolumeAttachment {
 	errorCode := int32(code)
 	va.Status.AttachError = &storage.VolumeError{
@@ -535,7 +553,7 @@ func TestCSIHandler(t *testing.T) {
 			expectedActions: []core.Action{
 				// PV Finalizer after VA
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pv(), pvWithFinalizer())),
+					types.JSONPatchType, pvAddFinalizerJSON(pv())),
 				// VA Finalizer is saved last
 				// Finalizer is saved first
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
@@ -574,7 +592,7 @@ func TestCSIHandler(t *testing.T) {
 			expectedActions: []core.Action{
 				// PV Finalizer - fails
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pv(), pvWithFinalizer())),
+					types.JSONPatchType, pvAddFinalizerJSON(pv())),
 				// Error is saved
 				core.NewPatchSubresourceAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
 					types.MergePatchType, patch(va(false /*attached*/, "" /*finalizer*/, nil /* annotations */),
@@ -583,7 +601,7 @@ func TestCSIHandler(t *testing.T) {
 								" error")), "status"),
 				// Second PV Finalizer - succeeds
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pv(), pvWithFinalizer())),
+					types.JSONPatchType, pvAddFinalizerJSON(pv())),
 				// VA Finalizer is saved first, error remains
 				core.NewPatchAction(vaGroupResourceVersion, metav1.NamespaceNone, testPVName+"-"+testNodeName,
 					types.MergePatchType, patch(
@@ -1295,8 +1313,7 @@ func TestCSIHandler(t *testing.T) {
 			deletedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(pvWithFinalizer()),
-						pvDeleted(pv()))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(pvWithFinalizer())),
 			},
 		},
 		{
@@ -1305,8 +1322,7 @@ func TestCSIHandler(t *testing.T) {
 			deletedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(gcePDPVWithFinalizer()),
-						pvDeleted(gcePDPV()))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(gcePDPVWithFinalizer())),
 			},
 		},
 		{
@@ -1325,8 +1341,7 @@ func TestCSIHandler(t *testing.T) {
 			updatedPV:      pvDeleted(pvWithFinalizer()),
 			expectedActions: []core.Action{
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(pvWithFinalizer()),
-						pvDeleted(pv()))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(pvWithFinalizer())),
 			},
 		},
 		{
@@ -1335,7 +1350,7 @@ func TestCSIHandler(t *testing.T) {
 			deletedVA:      va(false, "", nil),
 			expectedActions: []core.Action{
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(pvWithFinalizers(pvWithFinalizer(), "foo/bar", "bar/baz")), pvDeleted(pvWithFinalizers(pv(), "foo/bar", "bar/baz")))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(pvWithFinalizers(pvWithFinalizer(), "foo/bar", "bar/baz"))),
 			},
 		},
 		{
@@ -1361,13 +1376,13 @@ func TestCSIHandler(t *testing.T) {
 			expectedActions: []core.Action{
 				// This update fails
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(pvWithFinalizer()), pvDeleted(pv()))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(pvWithFinalizer())),
 				// This one fails too
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(pvWithFinalizer()), pvDeleted(pv()))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(pvWithFinalizer())),
 				// This one succeeds
 				core.NewPatchAction(pvGroupResourceVersion, metav1.NamespaceNone, testPVName,
-					types.MergePatchType, patch(pvDeleted(pvWithFinalizer()), pvDeleted(pv()))),
+					types.JSONPatchType, pvRemoveFinalizerJSON(pvWithFinalizer())),
 			},
 		},
 		{

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -225,3 +225,70 @@ func createMergePatch(original, new any) ([]byte, error) {
 	}
 	return patch, nil
 }
+
+// addFinalizerPatch creates a JSON Patch (RFC 6902) that appends a single
+// finalizer to the metadata.finalizers array without replacing the whole list.
+// This avoids a race where a merge-patch based on a stale informer cache
+// inadvertently re-adds finalizers that other controllers have already removed,
+// which causes 422 errors when the object is being deleted.
+// See https://github.com/kubernetes-csi/external-provisioner/issues/1217.
+func addFinalizerPatch(existingFinalizers []string, finalizerName string) ([]byte, error) {
+	type patchOp struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value"`
+	}
+
+	var ops []patchOp
+	switch {
+	case existingFinalizers == nil:
+		ops = []patchOp{
+			{Op: "test", Path: "/metadata/finalizers", Value: nil},
+			{Op: "add", Path: "/metadata/finalizers", Value: []string{finalizerName}},
+		}
+	case len(existingFinalizers) == 0:
+		ops = []patchOp{
+			{Op: "test", Path: "/metadata/finalizers", Value: existingFinalizers},
+			{Op: "replace", Path: "/metadata/finalizers", Value: []string{finalizerName}},
+		}
+	default:
+		ops = []patchOp{
+			{Op: "add", Path: "/metadata/finalizers/-", Value: finalizerName},
+		}
+	}
+	return json.Marshal(ops)
+}
+
+// removeFinalizerPatch creates a JSON Patch (RFC 6902) that removes exactly one
+// finalizer from metadata.finalizers by index, after verifying its value with a
+// "test" operation. If the array has been concurrently modified (e.g. by another
+// controller removing a different finalizer), the test fails atomically and the
+// caller should retry with a fresh read.
+// This prevents the race condition where a merge-patch based on a stale cache
+// inadvertently re-adds finalizers removed by other controllers.
+// See https://github.com/kubernetes-csi/external-provisioner/issues/1217.
+func removeFinalizerPatch(existingFinalizers []string, finalizerName string) ([]byte, error) {
+	type patchOp struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value,omitempty"`
+	}
+
+	idx := -1
+	for i, f := range existingFinalizers {
+		if f == finalizerName {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, fmt.Errorf("finalizer %q not found in list", finalizerName)
+	}
+
+	path := fmt.Sprintf("/metadata/finalizers/%d", idx)
+	ops := []patchOp{
+		{Op: "test", Path: path, Value: finalizerName},
+		{Op: "remove", Path: path},
+	}
+	return json.Marshal(ops)
+}

--- a/pkg/controller/util_test.go
+++ b/pkg/controller/util_test.go
@@ -274,6 +274,106 @@ func TestGetFinalizerName(t *testing.T) {
 	}
 }
 
+func TestAddFinalizerPatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		finalizers []string
+		finalizer  string
+		wantPatch  string
+		wantErr    bool
+	}{
+		{
+			name:       "add to nil finalizers",
+			finalizers: nil,
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"test","path":"/metadata/finalizers","value":null},{"op":"add","path":"/metadata/finalizers","value":["external-attacher/ebs-csi-aws-com"]}]`,
+		},
+		{
+			name:       "add to empty finalizers",
+			finalizers: []string{},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"test","path":"/metadata/finalizers","value":[]},{"op":"replace","path":"/metadata/finalizers","value":["external-attacher/ebs-csi-aws-com"]}]`,
+		},
+		{
+			name:       "add to existing finalizers preserves others",
+			finalizers: []string{"external-provisioner.volume.kubernetes.io/finalizer", "kubernetes.io/pv-protection"},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"add","path":"/metadata/finalizers/-","value":"external-attacher/ebs-csi-aws-com"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addFinalizerPatch(tt.finalizers, tt.finalizer)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("addFinalizerPatch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if string(got) != tt.wantPatch {
+				t.Errorf("addFinalizerPatch() =\n  %s\nwant:\n  %s", string(got), tt.wantPatch)
+			}
+		})
+	}
+}
+
+func TestRemoveFinalizerPatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		finalizers []string
+		finalizer  string
+		wantPatch  string
+		wantErr    bool
+	}{
+		{
+			name:       "remove sole finalizer",
+			finalizers: []string{"external-attacher/ebs-csi-aws-com"},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"test","path":"/metadata/finalizers/0","value":"external-attacher/ebs-csi-aws-com"},{"op":"remove","path":"/metadata/finalizers/0"}]`,
+		},
+		{
+			name:       "remove first of many",
+			finalizers: []string{"external-attacher/ebs-csi-aws-com", "kubernetes.io/pv-protection", "external-provisioner.volume.kubernetes.io/finalizer"},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"test","path":"/metadata/finalizers/0","value":"external-attacher/ebs-csi-aws-com"},{"op":"remove","path":"/metadata/finalizers/0"}]`,
+		},
+		{
+			name:       "remove middle finalizer leaves others untouched",
+			finalizers: []string{"external-provisioner.volume.kubernetes.io/finalizer", "external-attacher/ebs-csi-aws-com", "kubernetes.io/pv-protection"},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"test","path":"/metadata/finalizers/1","value":"external-attacher/ebs-csi-aws-com"},{"op":"remove","path":"/metadata/finalizers/1"}]`,
+		},
+		{
+			name:       "remove last finalizer",
+			finalizers: []string{"kubernetes.io/pv-protection", "external-attacher/ebs-csi-aws-com"},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantPatch:  `[{"op":"test","path":"/metadata/finalizers/1","value":"external-attacher/ebs-csi-aws-com"},{"op":"remove","path":"/metadata/finalizers/1"}]`,
+		},
+		{
+			name:       "finalizer not found",
+			finalizers: []string{"kubernetes.io/pv-protection"},
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantErr:    true,
+		},
+		{
+			name:       "nil finalizers",
+			finalizers: nil,
+			finalizer:  "external-attacher/ebs-csi-aws-com",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := removeFinalizerPatch(tt.finalizers, tt.finalizer)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("removeFinalizerPatch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && string(got) != tt.wantPatch {
+				t.Errorf("removeFinalizerPatch() =\n  %s\nwant:\n  %s", string(got), tt.wantPatch)
+			}
+		})
+	}
+}
+
 func TestGetVolumeHandle(t *testing.T) {
 	pv := &v1.PersistentVolume{
 		Spec: v1.PersistentVolumeSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR replaces the CSI handler's patchPV (which uses a merge patch) with a  JSON patch (RFC 6902).

The problem with the merge patch is that if the controller holds a stale copy of the resource (which is likely if two controllers are trying to mutate finalizers at the same time),  finalizers may be added back inadvertently.

The problem this is solving is benign, but should solve it nonetheless. 
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-csi/external-provisioner/issues/1217

**Special notes for your reviewer**:

**Code created using claude-4.6-opus** (but reviewed and PR written by a human :) )

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
