### PR TITLE
Log work queue backlog to surface queued attach/detach work

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Note that the external-attacher does not scale with more replicas. Only one exte
 
 * `--reconcile-sync`: Resync frequency of the attached volumes with the driver. See [Periodic re-sync](#periodic-re-sync) for details. 1 minute is used by default.
 
+* `--log-backlog-interval`: Interval at which the depth of the VolumeAttachment and PersistentVolume work queues is logged whenever there is a backlog. A growing backlog usually means `--worker-threads` is too low for the current attach/detach load. The depth is also exported as the `workqueue_depth` metric. 30 seconds is used by default. Set to 0 to disable.
+
 * `--kube-api-qps`: The number of requests per second sent by a Kubernetes client to the Kubernetes API server. Defaults to `5.0`.
 
 * `--kube-api-burst`: The number of requests to the Kubernetes API server, exceeding the QPS, that can be sent at any given time. Defaults to `10`.

--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -75,6 +75,8 @@ var (
 
 	reconcileSync = flag.Duration("reconcile-sync", 1*time.Minute, "Resync interval of the VolumeAttachment reconciler.")
 
+	logBacklogInterval = flag.Duration("log-backlog-interval", 30*time.Second, "Interval at which the depth of the VolumeAttachment and PersistentVolume work queues is logged when there is a backlog. Set to 0 to disable.")
+
 	maxGRPCLogLength = flag.Int("max-grpc-log-length", -1, "The maximum amount of characters logged for every grpc responses. Defaults to no limit")
 
 	featureGates map[string]bool
@@ -276,6 +278,7 @@ func main() {
 		workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax),
 		supportsListVolumesPublishedNodes,
 		*reconcileSync,
+		*logBacklogInterval,
 	)
 	// handle SIGTERM and SIGINT by cancelling the context.
 	var (

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -59,6 +59,7 @@ type CSIAttachController struct {
 
 	shouldReconcileVolumeAttachment bool
 	reconcileSync                   time.Duration
+	logBacklogInterval              time.Duration
 	translator                      AttacherCSITranslator
 }
 
@@ -91,6 +92,7 @@ func NewCSIAttachController(
 	vaRateLimiter, paRateLimiter workqueue.TypedRateLimiter[string],
 	shouldReconcileVolumeAttachment bool,
 	reconcileSync time.Duration,
+	logBacklogInterval time.Duration,
 ) *CSIAttachController {
 	ctrl := &CSIAttachController{
 		client:                          client,
@@ -100,6 +102,7 @@ func NewCSIAttachController(
 		pvQueue:                         workqueue.NewTypedRateLimitingQueueWithConfig(paRateLimiter, workqueue.TypedRateLimitingQueueConfig[string]{Name: "csi-attacher-pv"}),
 		shouldReconcileVolumeAttachment: shouldReconcileVolumeAttachment,
 		reconcileSync:                   reconcileSync,
+		logBacklogInterval:              logBacklogInterval,
 		translator:                      csitrans.New(),
 	}
 
@@ -136,6 +139,14 @@ func (ctrl *CSIAttachController) Run(ctx context.Context, workers int, wg *sync.
 		logger.Error(nil, "Cannot sync caches")
 		return
 	}
+
+	// Periodically log the depth of the work queues so that an operator can
+	// see a growing backlog (e.g. when worker-threads is set too low) directly
+	// in the logs, without having to scrape the workqueue_depth metric.
+	if ctrl.logBacklogInterval > 0 {
+		go wait.UntilWithContext(ctx, ctrl.logBacklog, ctrl.logBacklogInterval)
+	}
+
 	if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
 		for i := 0; i < workers; i++ {
 			wg.Add(1)
@@ -179,6 +190,20 @@ func (ctrl *CSIAttachController) Run(ctx context.Context, workers int, wg *sync.
 	}
 
 	<-ctx.Done()
+}
+
+// logBacklog logs the current depth of the VolumeAttachment and PersistentVolume
+// work queues. It only logs when there is a backlog, so that a healthy attacher
+// with empty queues stays quiet, but a growing backlog (which delays attach /
+// detach operations) becomes visible in the logs.
+func (ctrl *CSIAttachController) logBacklog(ctx context.Context) {
+	vaDepth := ctrl.vaQueue.Len()
+	pvDepth := ctrl.pvQueue.Len()
+	if vaDepth == 0 && pvDepth == 0 {
+		return
+	}
+	logger := klog.FromContext(ctx)
+	logger.Info("Work queue backlog", "volumeAttachmentQueueDepth", vaDepth, "persistentVolumeQueueDepth", pvDepth)
 }
 
 // vaAdded reacts to a VolumeAttachment creation

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 	csitrans "k8s.io/csi-translation-lib"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init"
 )
 
 func TestShouldEnqueueVAChange(t *testing.T) {
@@ -241,5 +246,60 @@ func TestProcessFinalizers(t *testing.T) {
 		if result != tc.expectedResult {
 			t.Errorf("Error executing test %v: expected result %v, got %v", tc.name, tc.expectedResult, result)
 		}
+	}
+}
+
+func TestLogBacklog(t *testing.T) {
+	testcases := []struct {
+		name      string
+		vaItems   []string
+		pvItems   []string
+		expectLog bool
+	}{
+		{
+			name:      "empty queues stay quiet",
+			expectLog: false,
+		},
+		{
+			name:      "VolumeAttachment backlog is logged",
+			vaItems:   []string{"va-1", "va-2"},
+			expectLog: true,
+		},
+		{
+			name:      "PersistentVolume backlog is logged",
+			pvItems:   []string{"pv-1"},
+			expectLog: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+			ctx := klog.NewContext(context.Background(), logger)
+
+			c := &CSIAttachController{
+				vaQueue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				pvQueue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+			}
+			for _, item := range tc.vaItems {
+				c.vaQueue.Add(item)
+			}
+			for _, item := range tc.pvItems {
+				c.pvQueue.Add(item)
+			}
+
+			c.logBacklog(ctx)
+
+			var gotLog bool
+			for _, entry := range logger.GetSink().(ktesting.Underlier).GetBuffer().Data() {
+				if entry.Message == "Work queue backlog" {
+					gotLog = true
+					break
+				}
+			}
+			if gotLog != tc.expectLog {
+				t.Errorf("expected backlog log %v, got %v", tc.expectLog, gotLog)
+			}
+		})
 	}
 }

--- a/pkg/controller/framework_test.go
+++ b/pkg/controller/framework_test.go
@@ -184,7 +184,7 @@ func runTests(t *testing.T, handlerFactory handlerFactory, tests []testCase) {
 			lister := &fakeLister{t: t, publishedNodes: test.listerResponse}
 			csiConnection := &fakeCSIConnection{t: t, calls: test.expectedCSICalls, lister: lister}
 			handler := handlerFactory(client, informers, csiConnection, lister)
-			ctrl := NewCSIAttachController(logger, client, testAttacherName, handler, vaInformer, pvInformer, workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.DefaultTypedControllerRateLimiter[string](), test.listerResponse != nil, 1*time.Minute)
+			ctrl := NewCSIAttachController(logger, client, testAttacherName, handler, vaInformer, pvInformer, workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.DefaultTypedControllerRateLimiter[string](), test.listerResponse != nil, 1*time.Minute, 30*time.Second)
 
 			// Start the test by enqueueing the right event
 			if test.addedVA != nil {


### PR DESCRIPTION
The external-attacher processes VolumeAttachment and PersistentVolume events through rate-limited work queues. When the queues build up a backlog (for example, when --worker-threads is set too low for the attach/detach load), there is no signal in the logs. Operators only see individual items being processed, not the size of the pile waiting behind them, which makes it hard to tell that the attacher is overwhelmed and that throughput needs to be increased.

Add a periodic log line that reports the depth of the VolumeAttachment and PersistentVolume queues. It is emitted only while a backlog exists, so a healthy attacher with empty queues stays quiet. The interval is controlled by the new --log-backlog-interval flag (default 30s, 0 to disable). The depth is also already exported as the workqueue_depth metric; this makes the same signal visible to anyone reading logs without a metrics pipeline.

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Adds logging visibility to the queue depth for the controller which will clue an operator into a developing backlog of work.  Without this change operators do not have log events which will lead them to conclude they do not have enough worker threads.

**Which issue(s) this PR fixes**:

Fixes #706 

**Special notes for your reviewer**:

Good luck everyone, this is my first `go` change

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Output log events when a backlog of queued work exists
```
